### PR TITLE
Example image uploader route

### DIFF
--- a/examples/rails/image-uploader/config/routes.rb
+++ b/examples/rails/image-uploader/config/routes.rb
@@ -1,3 +1,3 @@
 ImageUploader::Application.routes.draw do
-  post 'images' => 'images#create' # Uploads!
+  post 'attachments' => 'images#create' # Uploads!
 end


### PR DESCRIPTION
Default route for image uploader example should be /attachments as per defaults in sir-trevor-js
