### PR TITLE
Regex for toHTML was failing on links when multiple markdown links are present in pasted in content

### DIFF
--- a/lib/sir-trevor.js
+++ b/lib/sir-trevor.js
@@ -2288,7 +2288,7 @@
       
       html =  html.replace(/^\> (.+)$/mg,"$1")                                       // Blockquotes
                   .replace(/\n\n/g,"<br>")                                           // Give me some <br>s
-                  .replace(/\[(.+)\]\((.+)\)/g,"<a href='$2'>$1</a>")                 // Links
+                  .replace(/\[([^\]]+)\]\(([^\)]+)\)/g,"<a href='$2'>$1</a>")                 // Links
                   .replace(/(?:_)([^*|_]+)(?:_)/mg,"<i>$1</i>")                   // Italic
                   .replace(/(?:\*\*)([^*|_]+)(?:\*\*)/mg,"<b>$1</b>");                // Bold
          


### PR DESCRIPTION
All your regex r belong to me.

On a side note, I'm sort of allergic to any form of parsing on paste like this, it's prone to breakage, especially when considering the constantly shifting specs of browsers' contenteditable fields.

The idea behind this editor was to avoid this sort of WYSIWYG parsing beyond what browsers do by default, but I understand that convincing some people to deal with Markdown could be difficult...

Just a thought.
