### PR TITLE
Fix editor spec

### DIFF
--- a/spec/javascripts/editor.spec.js
+++ b/spec/javascripts/editor.spec.js
@@ -1,6 +1,7 @@
 describe("a SirTrevor.Editor instance", function(){
   
-  var editor, editor_with_options, element = $("<textarea>");
+  var editor, editor_with_options,
+      element = $("<textarea>");
   
   beforeEach(function (){
     SirTrevor.instances = [];
@@ -18,11 +19,6 @@ describe("a SirTrevor.Editor instance", function(){
       }
     );
     
-  });
-  
-  afterEach(function (){
-    delete editor;
-    delete editor_with_options;
   });
   
   it("should fail if no element is passed", function() {


### PR DESCRIPTION
This was causing a failure for me on CI, see mention in pull request https://github.com/madebymany/sir-trevor-js/pull/10

I think the `afterEach` can be removed as both instances are reset in the `beforeEach` block. Also, this takes care of resetting the value of `instances` to an empty array. I think it makes sense to leave the rest to the garbage collector.

At the top there's a small indentation change which helps a bit with clarity, but that's more a personal opinion.
