### PR TITLE
Extract Pastable & Uploadable into separate mixins. 

### DIFF
--- a/dist/sir-trevor.css
+++ b/dist/sir-trevor.css
@@ -213,7 +213,7 @@
 ul.st-text-block {
   margin-left: 1.875em; }
 
-.st-block__dropzone {
+.st-block__inputs {
   padding: 1.6em 0 1em;
   border-radius: 0.3em;
   background: #f3f3f3;
@@ -236,7 +236,7 @@ ul.st-text-block {
   text-transform: lowercase;
   font-weight: 700; }
 
-.st-drag-over .st-block__dropzone {
+.st-drag-over .st-block__inputs {
   border-top-color: #cdcdcd; }
 
 .st-block .st-block__paste-input[type="text"] {

--- a/src/block_mixins/droppable.js
+++ b/src/block_mixins/droppable.js
@@ -6,28 +6,21 @@ SirTrevor.BlockMixins.Droppable = {
   valid_drop_file_types: ['File', 'Files', 'text/plain', 'text/uri-list'],
 
   initializeDroppable: function() {
-    SirTrevor.log("Adding drag and drop capabilities for block " + this.blockID);
+    SirTrevor.log("Adding droppable to block " + this.blockID);
 
-    this.drop_options = _.extend({}, SirTrevor.DEFAULTS.default_drop_options, this.drop_options);
+    this.drop_options = _.extend({}, SirTrevor.DEFAULTS.Block.drop_options, this.drop_options);
 
-    // Build the dropzone interface
-    var drop_html = $(_.template(this.drop_options.drop_html, this));
-
-    if (this.drop_options.pastable) {
-      drop_html.append(this.drop_options.paste_html);
-    }
-
-    if (this.drop_options.uploadable) {
-      drop_html.append(this.drop_options.upload_html);
-    }
+    var drop_html = $(_.template(this.drop_options.html, this));
 
     this.$editor.hide();
-    this.$inner.append(drop_html).addClass('st-block__inner--droppable');
+    this.$inputs.append(drop_html);
     this.$dropzone = drop_html;
 
     // Bind our drop event
     this.$dropzone.dropArea()
                   .bind('drop', _.bind(this._handleDrop, this));
+
+    this.$inner.addClass('st-block__inner--droppable');
   },
 
   _handleDrop: function(e) {

--- a/src/block_mixins/pastable.js
+++ b/src/block_mixins/pastable.js
@@ -1,0 +1,17 @@
+SirTrevor.BlockMixins.Pastable = {
+
+  mixinName: "Pastable",
+
+  initializePastable: function() {
+    SirTrevor.log("Adding pastable to block " + this.blockID);
+
+    this.paste_options = _.extend({}, SirTrevor.DEFAULTS.Block.paste_options, this.paste_options);
+    this.$inputs.append(_.template(this.paste_options.html, this));
+
+    this.$('.st-paste-block')
+      .bind('click', function(){ $(this).select(); })
+      .bind('paste', this._handleContentPaste)
+      .bind('submit', this._handleContentPaste);
+  }
+
+};

--- a/src/block_mixins/uploadable.js
+++ b/src/block_mixins/uploadable.js
@@ -1,0 +1,14 @@
+SirTrevor.BlockMixins.Uploadable = {
+
+  mixinName: "Uploadable",
+
+  uploadsCount: 0,
+
+  initializeUploadable: function() {
+    SirTrevor.log("Adding uploadable to block " + this.blockID);
+
+    this.upload_options = _.extend({}, SirTrevor.DEFAULTS.Block.upload_options, this.upload_options);
+    this.$inputs.append(_.template(this.upload_options.html, this));
+  }
+
+};

--- a/src/blocks/image.js
+++ b/src/blocks/image.js
@@ -5,11 +5,9 @@
 SirTrevor.Blocks.Image = SirTrevor.Block.extend({
 
   type: "Image",
-  droppable: true,
 
-  drop_options: {
-    uploadable: true
-  },
+  droppable: true,
+  uploadable: true,
 
   loadData: function(data){
     // Create our image tag
@@ -18,8 +16,8 @@ SirTrevor.Blocks.Image = SirTrevor.Block.extend({
 
   onBlockRender: function(){
     /* Setup the upload button */
-    this.$dropzone.find('button').bind('click', function(ev){ ev.preventDefault(); });
-    this.$dropzone.find('input').on('change', _.bind(function(ev){
+    this.$inputs.find('button').bind('click', function(ev){ ev.preventDefault(); });
+    this.$inputs.find('input').on('change', _.bind(function(ev){
       this.onDrop(ev.currentTarget);
     }, this));
   },
@@ -32,7 +30,7 @@ SirTrevor.Blocks.Image = SirTrevor.Block.extend({
     if (/image/.test(file.type)) {
       this.loading();
       // Show this image on here
-      this.$dropzone.hide();
+      this.$inputs.hide();
       this.$editor.html($('<img>', { src: urlAPI.createObjectURL(file) })).show();
 
       // Upload!

--- a/src/blocks/tweet.js
+++ b/src/blocks/tweet.js
@@ -13,8 +13,9 @@ SirTrevor.Blocks.Tweet = (function(){
 
     type: "Tweet",
     droppable: true,
+    pastable: true,
+
     drop_options: {
-      pastable: true,
       re_render_on_reorder: true
     },
 

--- a/src/blocks/video.js
+++ b/src/blocks/video.js
@@ -7,10 +7,7 @@ SirTrevor.Blocks.Video = (function(){
     type: 'Video',
 
     droppable: true,
-
-    drop_options: {
-      pastable: true
-    },
+    pastable: true,
 
     loadData: function(data){
       this.$editor.addClass('st-block__editor--with-sixteen-by-nine-media');

--- a/src/sass/block.scss
+++ b/src/sass/block.scss
@@ -77,7 +77,7 @@ ul.st-text-block {
   margin-left: 1.875em;
 }
 
-.st-block__dropzone {
+.st-block__inputs {
   padding: 1.6em 0 1em;
   border-radius: 0.3em;
   background: $blocks-control-bg-color;
@@ -104,7 +104,7 @@ ul.st-text-block {
   font-weight: 700;
 }
 
-.st-drag-over .st-block__dropzone {
+.st-drag-over .st-block__inputs {
   border-top-color: darken($blocks-control-bg-color, 15%);
 }
 


### PR DESCRIPTION
Has a few BREAKING API changes by doing this, had to change the image, tweet and video blocks to work with the new format. Also, have added a new  element when the block is pasteable / uploadable or droppable. This allows us to easily show / hide controls as before without tying ecverything to droppable.

@ninjabiscuit you should check this out and make sure it meets your requirements before we merge this in :thumbsup: 
