### PR TITLE
Ensure bower.json example uses valid JSON

### DIFF
--- a/website/source/partials/docs/_1.html.markdown
+++ b/website/source/partials/docs/_1.html.markdown
@@ -11,8 +11,8 @@ Sir Trevor provides a means to transform a text input into a rich content editor
 The easiest way to install Sir Trevor is with [Bower](), the front-end package manager from Twitter. If you do use Bower, your `bower.json` file should look something like this:
 
     {
-      name: "your-project",
-      dependencies: {
+      "name": "your-project",
+      "dependencies": {
         "sir-trevor-js": "0.3.0"
       }
     }


### PR DESCRIPTION
I appreciate this is a minuscule change but it might save people a bit of time - the bower.json example isn't actually valid JSON, which results in a potentially confusing error:

```
bower                       EMALFORMED Failed to read /home/nick/repo/bower.json

Additional error details:
Unexpected token n
```

This PR simply encapsulates the keys in quotes to make the JSON valid.

Apologies about the addition of a newline at EOF; I've submitted this PR via GitHub's web interface. I didn't go anywhere near that last line.
