### PR TITLE
Update to-markdown.js

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -61,7 +61,7 @@ SirTrevor.toMarkdown = function(content, type) {
 
   // Use custom formatters toMarkdown functions (if any exist)
   var formatName, format;
-  for(formatName in this.formatters) {
+  for(formatName in this.Formatters) {
     if (SirTrevor.Formatters.hasOwnProperty(formatName)) {
       format = SirTrevor.Formatters[formatName];
       // Do we have a toMarkdown function?


### PR DESCRIPTION
As I could test, toMarkdown of custom formatters weren't being called.

In the context of the 'for' (line 64), 'this' is equal to SirTrevor and SirTrevor.formatters is undefined. I believe the correct should be SirTrevor.Formatters or this.Formatters.
