### PR TITLE
Lo-Dash / Underscore compatibility fix

### DIFF
--- a/sir-trevor.js
+++ b/sir-trevor.js
@@ -64,7 +64,7 @@
     bound: [],
     _bindFunctions: function(){
       if (this.bound.length > 0) {
-        _.bindAll.apply(null, _.union(this, this.bound));
+        _.bindAll.apply(null, _.union([this], this.bound));
       }
     }
   };

--- a/src/sir-trevor.js
+++ b/src/sir-trevor.js
@@ -55,7 +55,7 @@
     bound: [],
     _bindFunctions: function(){
       if (this.bound.length > 0) {
-        _.bindAll.apply(null, _.union(this, this.bound));
+        _.bindAll.apply(null, _.union([this], this.bound));
       }
     }
   };


### PR DESCRIPTION
`Lo-Dash` currently drops non-array elements in `_.union`. As a result `FunctionBind` doesn't work when using `Lo-Dash`. Since `this` isn't an array, the first parameter by `apply` for `_.bindAll` is set to the first element of `this.bound` instead.

In the current version of `Underscore`, `_.union` will `push` non-array elements and merge arrays. However,  `Underscore` has decided to follow the `Lo-Dash` approach (see: https://github.com/jashkenas/underscore/pull/1317). So soon this will be a problem with `Underscore`, like it currently is with `Lo-Dash`. By wrapping the `this` in an array, `FunctionBind` will work with the current and future versions of `Lo-Dash` and `Underscore`.
