### PR TITLE
moved pushing the editor to ST.instances before building blocks

### DIFF
--- a/src/sir-trevor-editor.js
+++ b/src/sir-trevor-editor.js
@@ -48,9 +48,11 @@ SirTrevor.Editor = (function(){
       this._bindFunctions();
 
       this.store("create");
-      this.build();
-
+      
       SirTrevor.instances.push(this);
+      
+      this.build();
+      
       SirTrevor.bindFormSubmit(this.$form);
     },
 


### PR DESCRIPTION
I ran into a situation where it would have been helpful to have access to the ST instance when building the initial set of blocks. This was in a single page application / CMS where certain options for a block depended on what resource was currently being operated on (passed as an option to the editor instance).

Moving the place where pushing the editor instance onto the global stack would solve this for me. 

All tests still passing.
