### PR TITLE
Allow Format Bar container to be configured

### DIFF
--- a/spec/javascripts/units/editor/options.spec.js
+++ b/spec/javascripts/units/editor/options.spec.js
@@ -88,4 +88,19 @@ describe("Editor with options", function(){
 
   });
 
+  describe("setting the formatBarContainer", function(){
+    var formatBarContainer = $('<div/>');
+
+    beforeEach(function(){
+      editor = new SirTrevor.Editor({
+        el: element,
+        formatBarContainer: formatBarContainer
+      });
+    });
+
+    it('should append the formatBar to the container specified', function(){
+      expect(editor.formatBar.el.parentNode).toBe(formatBarContainer[0]);
+    });
+  });
+
 });

--- a/src/format-bar.js
+++ b/src/format-bar.js
@@ -59,10 +59,14 @@ SirTrevor.FormatBar = (function(){
       var selection = window.getSelection(),
           range = selection.getRangeAt(0),
           boundary = range.getBoundingClientRect(),
-          coords = {};
+          coords = {},
+          scrollTop = this.el.parentNode.scrollTop,
+          // in case the format bar is inside a scrollable container
+          leftOffset = this.el.parentNode.offsetLeft,
+          topOffset = this.el.parentNode.offsetTop;
 
-      coords.top = boundary.top + 20 + window.pageYOffset - this.$el.height() + 'px';
-      coords.left = ((boundary.left + boundary.right) / 2) - (this.$el.width() / 2) + 'px';
+      coords.top = boundary.top + 20 + scrollTop - this.$el.height() - topOffset + 'px';
+      coords.left = ((boundary.left + boundary.right) / 2) - (this.$el.width() / 2) - leftOffset + 'px';
 
       this.highlightSelectedButtons();
       this.show();

--- a/src/sir-trevor-editor.js
+++ b/src/sir-trevor-editor.js
@@ -78,7 +78,7 @@ SirTrevor.Editor = (function(){
       SirTrevor.EventBus.on("formatter:hide", this.formatBar.hide);
 
       this.$wrapper.prepend(this.fl_block_controls.render().$el);
-      $(document.body).append(this.formatBar.render().$el);
+      $(this.options.formatBarContainer).append(this.formatBar.render().$el);
       this.$outer.append(this.block_controls.render().$el);
 
       $(window).bind('click', this.hideAllTheThings);

--- a/src/sir-trevor.js
+++ b/src/sir-trevor.js
@@ -39,7 +39,8 @@
     required: [],
     uploadUrl: '/attachments',
     baseImageUrl: '/sir-trevor-uploads/',
-    errorsContainer: undefined
+    errorsContainer: undefined,
+    formatBarContainer: document.body
   };
 
   SirTrevor.BlockMixins = {};

--- a/website/source/partials/docs/_2.html.markdown
+++ b/website/source/partials/docs/_2.html.markdown
@@ -56,6 +56,14 @@ Call a function once the Editor has rendered.
       }
     }
 
+**`formatBarContainer`**
+Specify a container DOM element or jQuery object where the format bar is rendered in. This is useful if you're using Sir Trevor inside a scrollable element (i.e. 'overflow-y: scroll`).  
+*Defaults to `document.body`*
+
+    {
+      formatBarContainer: $('.my-format-bar-container')
+    }
+
 <a name="2-1"></a>
 ## Block Options
 


### PR DESCRIPTION
This is a non-breaking change that lets you specify the container for the FormatBar. This is useful if you're using Sir Trevor inside a scrollable element.

Here is an [example page](https://gist.github.com/cobbweb/8449414) to prove this works (you'll have to checkout my branch).

I had to add some more trickery to how the FormatBar calculates its position to support this but it works fine on my end. I avoided using jQuery because I know removing it is on the roadmap. I haven't written tests for this part yet, but might if I get time in the future.

I'm pretty sure the FormatBar position logic can be cleaned up a bit, and it also breaks if you specify a custom `formatBarContainer` that isn't scrollable.

I can appreciate if you think this might be an edge-case you'd rather not support. I've monkey-patched this in our app so it works for us :)

Also included are some miscellaneous changes to `package.json`... I can remove those commits and possibly create a separate PR if you wish. Might be easier to cherry-pick yourselves.

Fixes #161