### PR TITLE
Fix bug that prevents the format bar from showing

### DIFF
--- a/src/sir-trevor-editor.js
+++ b/src/sir-trevor-editor.js
@@ -74,7 +74,7 @@ SirTrevor.Editor = (function(){
       this._setEvents();
 
       SirTrevor.EventBus.on(this.ID + ":blocks:change_position", this.changeBlockPosition);
-      SirTrevor.EventBus.on("formatter:positon", this.formatBar.renderBySelection);
+      SirTrevor.EventBus.on("formatter:position", this.formatBar.renderBySelection);
       SirTrevor.EventBus.on("formatter:hide", this.formatBar.hide);
 
       this.$wrapper.prepend(this.fl_block_controls.render().$el);


### PR DESCRIPTION
The old event name had a typo in it, but it didn't get corrected on both ends when some code got refactored. This prevented the format bar from showing... don't know how no one noticed this :confused: 
