### PR TITLE
stop i18n stub from confusing ourself

### DIFF
--- a/src/locales.js
+++ b/src/locales.js
@@ -52,7 +52,7 @@ SirTrevor.Locales = {
   }
 };
 
-if (window.i18n === undefined) {
+if (window.i18n === undefined || window.i18n.init === undefined) {
   // Minimal i18n stub that only reads the English strings
   SirTrevor.log("Using i18n stub");
   window.i18n = {


### PR DESCRIPTION
Depending on the type of loading and unloading of scripts, our stub can confuse ourself if initialized again on the same (existing) window object. Eventually we could have negative side effects with this change, if somebody uses a i18n module w/o "init" - but that should be a rare edge case, IMHO.
