### PR TITLE
Don't focus block on Editor initialization with data

### DIFF
--- a/src/sir-trevor-editor.js
+++ b/src/sir-trevor-editor.js
@@ -200,7 +200,7 @@ SirTrevor.Editor = (function(){
       this.blocks.push(block);
       this._incrementBlockTypeCount(type);
 
-      block.focus();
+      !data && block.focus();
 
       SirTrevor.EventBus.trigger(data ? "block:create:existing" : "block:create:new", block);
       SirTrevor.log("Block created of type " + type);


### PR DESCRIPTION
For, example I use Sir Trevor as editor for photo album note. When app editor view has been loaded and Sir Trevor initialized then browser focuses on last initialized block of ST. ST Editor is not primary content in this app view so it is annoying that browser scroll to it. And it conflicts with more desired apps behavior to scroll top on new page or app view.

My commit **doesn't break** focus on block when new block is created by user. 

Screenshot where Editor could be secondary and shouldn't be focused on initialization with data:
![ST editor is not primary](http://cl.ly/WvOh/download/Image%202014-08-06%20at%205.22.01%20PM.png)
