### PR TITLE
Use lowercase type for consistency

### DIFF
--- a/src/blocks/heading.js
+++ b/src/blocks/heading.js
@@ -3,7 +3,7 @@
 */
 SirTrevor.Blocks.Heading = SirTrevor.Block.extend({
 
-  type: 'Heading',
+  type: 'heading',
 
   title: function(){ return i18n.t('blocks:heading:title'); },
 


### PR DESCRIPTION
All blocks have a lowercase `type` attribute except for header. Changed for consistency. 
