### PR TITLE
Blocks using droppable mixin throwing errors when rendering UI

### DIFF
--- a/src/block_mixins/droppable.js
+++ b/src/block_mixins/droppable.js
@@ -10,8 +10,7 @@ SirTrevor.BlockMixins.Droppable = {
 
     this.drop_options = _.extend({}, SirTrevor.DEFAULTS.Block.drop_options, this.drop_options);
 
-    var drop_html = $(_.template(this.drop_options.html,
-                      { block: this }));
+    var drop_html = $(_.template(this.drop_options.html)({ block: this }));
 
     this.$editor.hide();
     this.$inputs.append(drop_html);


### PR DESCRIPTION
+pass block var to the compiled template instead of as the second parameter to the _.template function. Was throwing an error before and not rendering the UI for droppables.
