### PR TITLE
Not ignoring src/blocks in bower.json, making it possible to use sir trevor forks with extra blocks as bower deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "**/.*",
     "node_modules",
     "components",
-    "src",
+    "src/!(blocks)",
     "spec",
     "examples",
     "website",


### PR DESCRIPTION
Related: https://github.com/madebymany/sir-trevor-js/issues/252
