### PR TITLE
fixed examples/index and replaced es6-shim

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -10,7 +10,7 @@
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width">
   <link rel="stylesheet" href="../sir-trevor-icons.css" type="text/css" media="screen" title="no title" charset="utf-8">
-  <link rel="stylesheet" href="../sir-trevor.css" type="text/css" media="screen" title="no title" charset="utf-8">
+  <link rel="stylesheet" href="../build/sir-trevor.css" type="text/css" media="screen" title="no title" charset="utf-8">
   <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro' rel='stylesheet' type='text/css'>
   <style>
     body {
@@ -31,7 +31,7 @@
   <!-- es6-shim should be bundled in with SirTrevor for now -->
   <!-- <script src="../node_modules/es6-shim/es6-shim.js" type="text/javascript" charset="utf-8"></script> -->
   <script src="../node_modules/jquery/dist/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="../sir-trevor.debug.js" type="text/javascript" charset="utf-8"></script>
+  <script src="../build/sir-trevor.debug.js" type="text/javascript" charset="utf-8"></script>
   <script src="../locales/de.js" type="text/javascript" charset="utf-8"></script>
   <script type="text/javascript" charset="utf-8">
     $(function(){

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "grunt dev watch"
   },
   "dependencies": {
+    "array.prototype.find": "^1.0.0",
     "es6-shim": "^0.21.0",
     "eventablejs": "^1.0.5",
     "lodash.isempty": "^2.4.1",
@@ -21,6 +22,7 @@
     "lodash.result": "^2.4.1",
     "lodash.template": "^2.4.1",
     "lodash.uniqueid": "^2.4.1",
+    "object.assign": "^1.1.1",
     "spin.js": "^2.0.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,12 @@
 
 var _ = require('./lodash');
 
-require('es6-shim'); // bundling in for the moment as support is very rare
-require('./helpers/event'); // extends jQuery itself
+// ES6 shims
+require('object.assign').shim();
+require('array.prototype.find');
 require('./vendor/array-includes'); // shims ES7 Array.prototype.includes
+
+require('./helpers/event'); // extends jQuery itself
 
 var SirTrevor = {
 


### PR DESCRIPTION
* removed full es6-shim and replaced with shims for individual functions (`Object.assign` and `Array.prototype.find`)