### PR TITLE
Adding 'Main' to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,11 @@
     "website",
     "BrowserRunner.html"
   ],
+  "main": [
+    "sir-trevor.js",
+    "sir-trevor.css",
+    "sir-trevor-icons.css"
+  ],
   "dependencies": {
     "es5-shim": "~v4.0.3",
     "es6-shim": "~0.21.0",


### PR DESCRIPTION
Adding 'Main' to bower.json, so distribution files can be found programatically.

https://github.com/bower/bower.json-spec#main

This allows 

```sh
bower list --paths
```

to point to the files that should be distributed, eg.

```
'sir-trevor-js': [
    'bower_components/sir-trevor-js/sir-trevor.js',
    'bower_components/sir-trevor-js/sir-trevor.css',
    'bower_components/sir-trevor-js/sir-trevor-icons.css'
  ]
```
