### PR TITLE
Text block supportMarkdown setting

### DIFF
--- a/spec/javascripts/units/block/text.spec.js
+++ b/spec/javascripts/units/block/text.spec.js
@@ -1,0 +1,67 @@
+"use strict";
+
+describe("Blocks: Text block", function() {
+  describe("with markdown support", function() {
+    var data;
+
+    var getSerializedData = function(data) {
+      var element = $("<textarea>");
+      var editor = new SirTrevor.Editor({ el: element });
+      var block = new SirTrevor.Blocks.Text(data, editor.ID, editor.mediator);
+      block.render();
+      block.save();
+
+      return block._getData();
+    };
+
+    beforeEach(function() {
+      data = {text: 'test'};
+    });
+
+    describe("on", function() {
+      beforeEach(function() { 
+        SirTrevor.setBlockOptions("Text", { markdownSupport: true });
+      });
+
+      // calling stToHtml on text block wraps everything in <p> tags,
+      // so I use it as an easy way of testing if the method was called
+      it('calls stToHtml on objects without isHtml set', function() {
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.text).toEqual('<p>test</p>');
+      });
+
+      it('sets isHtml true when saving', function() {
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.isHtml).toEqual(true);
+      });
+
+      it('doesn\'t call stToHtml on objects with isHtml set', function() {
+        data.isHtml = true;
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.text).toEqual('test');
+      });
+    });
+
+    describe("off", function() {
+      beforeEach(function() { 
+        SirTrevor.setBlockOptions("Text", { markdownSupport: false });
+      });
+
+      it('doesn\'t call stToHtml', function() {
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.text).toEqual('test');
+      });
+
+      it('ignores isHtml value', function() {
+        data.isHtml = false;
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.text).toEqual('test');
+      });
+    });
+  });
+});

--- a/spec/javascripts/units/block/text.spec.js
+++ b/spec/javascripts/units/block/text.spec.js
@@ -9,9 +9,8 @@ describe("Blocks: Text block", function() {
       var editor = new SirTrevor.Editor({ el: element });
       var block = new SirTrevor.Blocks.Text(data, editor.ID, editor.mediator);
       block.render();
-      block.save();
 
-      return block._getData();
+      return block.getBlockData();
     };
 
     beforeEach(function() {
@@ -54,6 +53,12 @@ describe("Blocks: Text block", function() {
         var serializedData = getSerializedData(data);
 
         expect(serializedData.text).toEqual('test');
+      });
+
+      it('doesn\'t set isHtml', function() {
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.isHtml).toBeUndefined();
       });
 
       it('ignores isHtml value', function() {

--- a/src/blocks/text.js
+++ b/src/blocks/text.js
@@ -19,10 +19,19 @@ module.exports = Block.extend({
 
   markdownSupport: true,
 
+  _serializeData: function() {
+    var data = Block.prototype._serializeData.apply(this);
+
+    if (Object.keys(data).length && this.markdownSupport) {
+      data.isHtml = true;
+    }
+
+    return data;
+  },
+
   loadData: function(data){
     if (this.markdownSupport && !data.isHtml) {
       this.getTextBlock().html(stToHTML(data.text, this.type));
-      data.isHtml = true;
     } else {
       this.getTextBlock().html(data.text);
     }

--- a/src/blocks/text.js
+++ b/src/blocks/text.js
@@ -17,7 +17,14 @@ module.exports = Block.extend({
 
   icon_name: 'text',
 
+  markdownSupport: true,
+
   loadData: function(data){
-    this.getTextBlock().html(stToHTML(data.text, this.type));
+    if (this.markdownSupport && !data.isHtml) {
+      this.getTextBlock().html(stToHTML(data.text, this.type));
+      data.isHtml = true;
+    } else {
+      this.getTextBlock().html(data.text);
+    }
   },
 });


### PR DESCRIPTION
As we're using html (Scribe) instead of markdown now, running everything through `toHtml` method doesn't make sense (and also wraps content in additional `<p>` tags on each save, which makes it unusable), but we still want to be able to support content created with older versions of Sir Trevor (and therefore stored in markdown).

Added `isHtml` field to data stored using Text field, so it doesn't run content saved with new version of Sir Trevor through `toHtml` method. When loading SirTrevor with markdown serialized content it will get converted to html and stored with `isHtml=true` to never run it through `toHtml` again.

You can also set `markdownSupport` to false on `TextBlock` to never run through `toHtml` method and never set `isHtml` on serialized data (useful for new installations of SirTrevor)
