### PR TITLE
Making mixins more extensible

### DIFF
--- a/src/block.js
+++ b/src/block.js
@@ -101,7 +101,17 @@ Object.assign(Block.prototype, SimpleBlock.fn, require('./block-validations'), {
 
     this.$editor = this.$inner.children().first();
 
-    if(this.droppable || this.pastable || this.uploadable) {
+    this.mixinsRequireInputs = false;
+    this.availableMixins.forEach(function(mixin) {
+      if (this[mixin]) {
+        var blockMixin = BlockMixins[utils.classify(mixin)];
+        if (!_.isUndefined(blockMixin.requireInputs) && blockMixin.requireInputs) {
+          this.mixinsRequireInputs = true;
+        }
+      }
+    }, this);
+
+    if(this.mixinsRequireInputs) {
       var input_html = $("<div>", { 'class': 'st-block__inputs' });
       this.$inner.append(input_html);
       this.$inputs = input_html;
@@ -243,7 +253,7 @@ Object.assign(Block.prototype, SimpleBlock.fn, require('./block-validations'), {
   beforeLoadingData: function() {
     this.loading();
 
-    if(this.droppable || this.uploadable || this.pastable) {
+    if(this.mixinsRequireInputs) {
       this.$editor.show();
       this.$inputs.hide();
     }

--- a/src/block_mixins/droppable.js
+++ b/src/block_mixins/droppable.js
@@ -13,6 +13,7 @@ module.exports = {
 
   mixinName: "Droppable",
   valid_drop_file_types: ['File', 'Files', 'text/plain', 'text/uri-list'],
+  requireInputs: true,
 
   initializeDroppable: function() {
     utils.log("Adding droppable to block " + this.blockID);

--- a/src/block_mixins/pastable.js
+++ b/src/block_mixins/pastable.js
@@ -8,6 +8,7 @@ var utils = require('../utils');
 module.exports = {
 
   mixinName: "Pastable",
+  requireInputs: true,
 
   initializePastable: function() {
     utils.log("Adding pastable to block " + this.blockID);

--- a/src/block_mixins/uploadable.js
+++ b/src/block_mixins/uploadable.js
@@ -11,6 +11,7 @@ module.exports = {
   mixinName: "Uploadable",
 
   uploadsCount: 0,
+  requireInputs: true,
 
   initializeUploadable: function() {
     utils.log("Adding uploadable to block " + this.blockID);


### PR DESCRIPTION
I've introduced a new property "requireInputs". This flag will be used at the Mixin level to indicate whether they need the block to create an st-block__inputs element. When adding non-core mixins to the available mixin list, it is not possible to indicate that the mixin requires inputs as it is hardcoded into core which mixins enable the st-block__inputs element. This method externalises this into each individual mixins to dictate if they need the st-block__inputs element.

Happy to adjust the approach as I was a bit unsure on the best method of attacking this problem without changing too much of the core. However, I do think something like this is necessary in order to support additional mixins without changing the core each time to make them compatible.