### PR TITLE
Fixed drag drop behaviour for elements that are not blocks and should not be dropped between blocks.

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -35,6 +35,7 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
 
   events: {
     'block:reorder:dragend': 'removeBlockDragOver',
+    'block:reorder:dropped': 'removeBlockDragOver',
     'block:content:dropped': 'removeBlockDragOver'
   },
 


### PR DESCRIPTION
To replicate this issue using the provided sample page, create a text or heading block and type something into it. Then, select the text you just typed and click drag it around the page. Dragging it around you will trigger the dropzones between blocks. Dropping the text into a dropzone will leave the dropzone in the wrong state and it continues to show the "Drop block here" text.