### PR TITLE
initTextBlocks should only be called for blocks with Text input

### DIFF
--- a/spec/javascripts/units/block/base.spec.js
+++ b/spec/javascripts/units/block/base.spec.js
@@ -85,6 +85,26 @@ describe("Block", function(){
       expect(block.checkAndLoadData).toHaveBeenCalled();
     });
 
-  });
+    describe('initTextBlocks', function() {
+      beforeEach(function() {
+        spyOn(block, '_initTextBlocks');
+      });
 
+      it('is called when block has text block', function() {
+        block.hasTextBlock = function() { return true; };
+
+        block.render();
+
+        expect(block._initTextBlocks).toHaveBeenCalled();
+      });
+
+      it('isn\'t called when block doesn\'t have text blocks', function() {
+        block.hasTextBlock = function() { return false; };
+
+        block.render();
+
+        expect(block._initTextBlocks).not.toHaveBeenCalled();
+      });
+    });
+  });
 });

--- a/src/block.js
+++ b/src/block.js
@@ -107,7 +107,7 @@ Object.assign(Block.prototype, SimpleBlock.fn, require('./block-validations'), {
       this.$inputs = input_html;
     }
 
-    if (this.hasTextBlock) { this._initTextBlocks(); }
+    if (this.hasTextBlock()) { this._initTextBlocks(); }
 
     this.availableMixins.forEach(function(mixin) {
       if (this[mixin]) {


### PR DESCRIPTION
I'm not sure about this.

I was looking for a way of disabling Scribe editor for a block with text field and I found out that making `_hasTextBlock` return false should be the right solution. However during `render` this function wasn't actually called, which I think might just be a mistake.