### PR TITLE
Updated version of scribe plugin link prompt command dependency which fixes handling for mailto links

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "object.assign": "^1.1.1",
     "scribe-editor": "^1.0.0",
     "scribe-plugin-formatter-plain-text-convert-new-lines-to-html": "^0.1.1",
-    "scribe-plugin-link-prompt-command": "^0.1.1",
+    "scribe-plugin-link-prompt-command": "^0.2.0",
     "spin.js": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
A new version of this dependency is available that offers a better experience with mailto links.

https://github.com/guardian/scribe-plugin-link-prompt-command