### PR TITLE
Feature/editor destroy fix

### DIFF
--- a/spec/javascripts/units/editor/base.spec.js
+++ b/spec/javascripts/units/editor/base.spec.js
@@ -139,7 +139,7 @@ describe("Editor", function(){
       ];
     });
 
-    it("returns all the blocks of the type", function(){
+    it("clears the blocks", function(){
       editor.destroy();
       expect(editor.block_manager.blocks.length).toBe(0);
     });

--- a/spec/javascripts/units/editor/base.spec.js
+++ b/spec/javascripts/units/editor/base.spec.js
@@ -127,4 +127,22 @@ describe("Editor", function(){
       expect(editor.getBlocksByIDs([1]).length).toBe(1);
     });
   });
+
+   describe("destroy", function(){
+
+    beforeEach(function(){
+      editor = new SirTrevor.Editor({ el: element });
+
+      editor.block_manager.blocks = [
+        { blockID: 1 },
+        { blockID: 2 }
+      ];
+    });
+
+    it("returns all the blocks of the type", function(){
+      editor.destroy();
+      expect(editor.block_manager.blocks.length).toBe(0);
+    });
+  });
+
 });

--- a/src/editor.js
+++ b/src/editor.js
@@ -31,7 +31,7 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
 
   bound: ['onFormSubmit', 'hideAllTheThings', 'changeBlockPosition',
     'removeBlockDragOver', 'renderBlock', 'resetBlockControls',
-    'blockLimitReached'], 
+    'blockLimitReached'],
 
   events: {
     'block:reorder:dragend': 'removeBlockDragOver',
@@ -122,8 +122,8 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
     this.block_controls.destroy();
 
     // Destroy all blocks
-    this.blocks.forEach(function(block) {
-      this.mediator.trigger('block:remove', this.block.blockID);
+    this.block_manager.blocks.forEach(function(block) {
+      this.mediator.trigger('block:remove', block.blockID);
     }, this);
 
     // Stop listening to events


### PR DESCRIPTION
Editor.destroy() had a bug - referencing the array this.blocks, when really that now exists in the block_manager.