### PR TITLE
List block supportMarkdown setting

### DIFF
--- a/spec/javascripts/units/block/list.spec.js
+++ b/spec/javascripts/units/block/list.spec.js
@@ -1,0 +1,81 @@
+"use strict";
+
+describe("Blocks: List block", function() {
+  var data;
+
+  var getSerializedData = function(data) {
+    var element = $("<textarea>");
+    var editor = new SirTrevor.Editor({ el: element });
+    var block = new SirTrevor.Blocks.List(data, editor.ID, editor.mediator);
+    block.render();
+
+    return block.getBlockData();
+  };
+
+  describe("with Markdown support", function() {
+    beforeEach(function() {
+      data = {text: ' - test'};
+    });
+
+    describe("on", function() {
+      beforeEach(function() { 
+        SirTrevor.setBlockOptions("List", { markdownSupport: true });
+      });
+
+      it('calls stToHtml on objects without isHtml set', function() {
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.text).toEqual('<ul><li>test</li></ul>');
+      });
+
+      it('sets isHtml true when saving', function() {
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.isHtml).toEqual(true);
+      });
+
+      it('doesn\'t call stToHtml on objects with isHtml set', function() {
+        data.isHtml = true;
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.text).toEqual(' - test');
+      });
+    });
+
+    describe("off", function() {
+      beforeEach(function() { 
+        SirTrevor.setBlockOptions("List", { markdownSupport: false });
+      });
+
+      it('doesn\'t call stToHtml', function() {
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.text).toEqual(' - test');
+      });
+
+      it('doesn\'t set isHtml', function() {
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.isHtml).toBeUndefined();
+      });
+
+      it('ignores isHtml value', function() {
+        data.isHtml = false;
+        var serializedData = getSerializedData(data);
+
+        expect(serializedData.text).toEqual(' - test');
+      });
+    });
+  });
+
+  describe("with HTML support", function() {
+    beforeEach(function() {
+      data = {text: '<ul><li>test1</li><li>test2</li></ul>'};
+    });
+
+    it("serialization does not change HTML", function() {
+      var serializedData = getSerializedData(data);
+      expect(serializedData.text).toEqual('<ul><li>test1</li><li>test2</li></ul>');
+    });
+  });
+});

--- a/src/blocks/list.js
+++ b/src/blocks/list.js
@@ -15,12 +15,18 @@ module.exports = Block.extend({
 
   icon_name: 'list',
 
+  markdownSupport: true,
+
   editorHTML: function() {
     return _.template(template, this);
   },
 
   loadData: function(data){
-    this.setTextBlockHTML("<ul>" + stToHTML(data.text, this.type) + "</ul>");
+    if (this.markdownSupport && !data.isHtml) {
+      this.getTextBlock().html('<ul>'+stToHTML(data.text, this.type)+'</ul>');
+    } else {
+      this.getTextBlock().html(data.text);
+    }
   },
 
   onBlockRender: function() {
@@ -56,6 +62,17 @@ module.exports = Block.extend({
 
   isEmpty: function() {
     return _.isEmpty(this.getBlockData().text);
-  }
+  },
+
+  _serializeData: function() {
+    var data = Block.prototype._serializeData.apply(this);
+
+    if (Object.keys(data).length && this.markdownSupport) {
+      //console.log('data.isHtml = true');
+      data.isHtml = true;
+    }
+
+    return data;
+  },
 
 });


### PR DESCRIPTION
In a similar vein to #301, i've enhanced the List block to also utilise the supportMarkdown setting.

This also fixes an issue that when rendering the content of the List block. To date on Master, when you saved a list of elements, the data saved would be something like this:

`{"data":[{"type":"list","data":{"text":"<ul><li>A</li><li>B</li><li>C<br></li></ul>"}}]}`

However, loading the ST editor with this data initially, the HTML within the contenteditable would be:

`<ul><ul><li>A</li><li>B</li><li>C<br></li></ul></ul>`

Essentially wrapping another `<ul>` around the existing `<ul>` in the block data.