### PR TITLE
Added ability to override the upload url in custom blocks

### DIFF
--- a/src/extensions/file-uploader.js
+++ b/src/extensions/file-uploader.js
@@ -43,8 +43,10 @@ module.exports = function(block, file, success, error) {
     }
   };
 
+  var url = block.uploadUrl || config.defaults.uploadUrl;
+
   var xhr = $.ajax({
-    url: config.defaults.uploadUrl,
+    url: url,
     data: data,
     cache: false,
     contentType: false,

--- a/website/source/partials/docs/_4.html.markdown
+++ b/website/source/partials/docs/_4.html.markdown
@@ -39,7 +39,7 @@ Provides a drop zone support for the block. Exposes the `onDrop` event which mus
 Provides the UI support for a pastable component (like the video block). You can override the default paste handler by re-implementing the `onContentPasted` method.
 
 **`uploadable`**
-Provides support for uploadable content and mixins in the uploader into the block.
+Provides support for uploadable content and mixins in the uploader into the block. The uploadable mixin will use the `uploadUrl` set in the `SirTrevor.setDefaults` by default. Your custom block can override this by defining `uploadUrl` in the block body.
 
 **`ajaxable`**
 Gives a way to fetch content remotely through a editor managed queue.


### PR DESCRIPTION
Hey,

I was working on a project using sir-trevor-js the other day and created several custom blocks, as part of this work I found that there was no good way to override the upload url for my custom blocks which resulted in less than optimal server side code.

This PR makes it possible to override the uploadUrl for custom blocks by setting uploadUrl in the body of the custom block, if no override is present the global default is used instead.

I've added some clarification around the use of uploadUrl in the documentation under Custom Blocks heading and a mention of the new feature detailed above.

Let me know what you think.

Thanks
.FxN