### PR TITLE
Update image.js

### DIFF
--- a/src/blocks/image.js
+++ b/src/blocks/image.js
@@ -15,7 +15,15 @@ module.exports = Block.extend({
 
   loadData: function(data){
     // Create our image tag
-    this.$editor.html($('<img>', { src: data.file.url }));
+    //this.$editor.html($('<img>', { src: data.file.url }));
+    //Added a function to check if URL is undefined when generating the data.file.url from a returned string (say when returning to a saved page)
+    this.$editor.html($('<img>', { src: function(){
+      if(typeof data.file[0]!=="undefined"){
+        return data.file[0].url
+      }else{
+        data.file.url
+      }
+    }));
   },
 
   onBlockRender: function(){


### PR DESCRIPTION
I found on testing that when returning a JSON string from a database that it wasn't also placing the saved image into the editor, on further investigation the 'data.file.url' object that should have been applied to the img tag being added into the image instance was being returned as 'undefined'. 

After checking to see that the data.file object existed, it turned out that it's being handled correctly for a JSON object and being created as an array instead of an object. As such it needs to be addressed as array 0. 

To do this I created a function to check if the data.file was an array or not and treat accordingly. That said it could be handled as '(!data.file[0])' and the returns reversed instead of '(typeof data.file[0]!=="undefined")'. But that's nitpicking for the sake of semantics.