### PR TITLE
Prevent BR tags in header block

### DIFF
--- a/src/blocks/heading.js
+++ b/src/blocks/heading.js
@@ -15,7 +15,7 @@ module.exports = Block.extend({
 
   editorHTML: '<div class="st-required st-text-block st-text-block--heading" contenteditable="true"></div>',
 
-  scribeOptions: { allowBlockElements: false },
+  scribeOptions: { allowBlockElements: true },
 
   icon_name: 'heading',
 


### PR DESCRIPTION
Changed scribeOptions - allowblockelements to 'true' to prevent extra BR tags being added