### PR TITLE
RegEx fixes for videos

### DIFF
--- a/src/blocks/video.js
+++ b/src/blocks/video.js
@@ -9,7 +9,7 @@ module.exports = Block.extend({
   // more providers at https://gist.github.com/jeffling/a9629ae28e076785a14f
   providers: {
     vimeo: {
-      regex: /(?:http[s]?:\/\/)?(?:www.)?vimeo\.com\/.+(?:\/)([^\/].*)+$/,
+      regex: /(?:http[s]?:\/\/)?(?:www.)?vimeo\.co(?:.+(?:\/)([^\/].*)+$)/,
       html: "<iframe src=\"<%= protocol %>//player.vimeo.com/video/<%= remote_id %>?title=0&byline=0\" width=\"580\" height=\"320\" frameborder=\"0\"></iframe>"
     },
     youtube: {

--- a/src/blocks/video.js
+++ b/src/blocks/video.js
@@ -9,11 +9,11 @@ module.exports = Block.extend({
   // more providers at https://gist.github.com/jeffling/a9629ae28e076785a14f
   providers: {
     vimeo: {
-      regex: /(?:http[s]?:\/\/)?(?:www.)?vimeo.com\/(.+)/,
+      regex: /(?:http[s]?:\/\/)?(?:www.)?vimeo\.com\/.+(?:\/)([^\/].*)+$/,
       html: "<iframe src=\"<%= protocol %>//player.vimeo.com/video/<%= remote_id %>?title=0&byline=0\" width=\"580\" height=\"320\" frameborder=\"0\"></iframe>"
     },
     youtube: {
-      regex: /^.*(?:youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/,
+      regex: /^.*(?:(youtu\.be|youtube\.com)\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*)/,
       html: "<iframe src=\"<%= protocol %>//www.youtube.com/embed/<%= remote_id %>\" width=\"580\" height=\"320\" frameborder=\"0\" allowfullscreen></iframe>"
     }
   },

--- a/src/blocks/video.js
+++ b/src/blocks/video.js
@@ -13,7 +13,7 @@ module.exports = Block.extend({
       html: "<iframe src=\"<%= protocol %>//player.vimeo.com/video/<%= remote_id %>?title=0&byline=0\" width=\"580\" height=\"320\" frameborder=\"0\"></iframe>"
     },
     youtube: {
-      regex: /^.*(?:(youtu\.be|youtube\.com)\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*)/,
+      regex: /^.*(?:(?:youtu\.be\/)|(?:youtube\.com)\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*)/,
       html: "<iframe src=\"<%= protocol %>//www.youtube.com/embed/<%= remote_id %>\" width=\"580\" height=\"320\" frameborder=\"0\" allowfullscreen></iframe>"
     }
   },


### PR DESCRIPTION
Found that the youtube and vimeo RegEx checks can bug out in certian circumstances. 

YouTube could fail oddly and only return the first character of the match, now fixed along with handling for both youtu.be and youtube.com addresses to be added) 

Vimeo would bug out if video id wasn't the first and only part of the path. 
(for example https://vimeo.com/channels/staffpicks/128544536 is a valid link but so is https://vimeo.com/128544536 but only the second link would get picked up. Now changed so that it finds the last forward slash after the vimeo web address.) 