### PR TITLE
Added note about scribe browser support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,8 @@ Sir Trevor is only tested on the following modern browsers:
 
 ECMAScript 6 shims are bundled in by default; if the platform you wish to run on doesn't support ECMAScript 5 APIs you'll need to shim those yourself.
 
+Sir Trevor uses [The Guardian's scribe](https://github.com/guardian/scribe) for rich text editing. Double check their [browser support](https://github.com/guardian/scribe#browser-support) if your application relies on full RTE support.
+
 ## Dependencies
 
 It's up to you:


### PR DESCRIPTION
Hey madebymany,

[scribe](https://github.com/guardian/scribe) only supports "Firefox >= 36, Chrome >= 41". Scribe does not work in IE and IE is not supported in their CI configuration. See https://github.com/guardian/scribe/issues/391

I didn't remove IE and Safari from the SirTrevor browser support because SirTrevor is different from scribe, but I think it's necessary to actively note the browser support of scribe.

Thanks.