### PR TITLE
Fixed format-bar and adding integration tests.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -196,7 +196,7 @@ module.exports = function(grunt) {
       },
       test: {
         specs: [
-          "spec/e2e/basic.spec.js"
+          "spec/e2e/*.spec.js"
         ]
       }
     }

--- a/spec/e2e/format-bar.spec.js
+++ b/spec/e2e/format-bar.spec.js
@@ -1,0 +1,109 @@
+'use strict';
+
+var helpers = require('./helpers');
+var driver = require('selenium-webdriver');
+
+var blockTypes = ["text"]; // jshint ignore:line
+
+describe('Format Bar', function() {
+
+  beforeEach( function() {
+    var data = {
+      "data": [
+        {
+          "type": "text",
+          "data": {
+            "text": "Bold, Italic, Link"
+          }
+        }
+      ]
+    };
+
+    helpers.initSirTrevor(data);
+  });
+
+  it('should not show as default', function(done) {
+    helpers.findElementByCss('.st-format-bar ').then(null, function(err) {
+      done();
+    });
+  });
+
+  it('should allow formatting of text', function(done) {
+
+    var testUrl = 'http://www.example.com';
+    var expectedHtmlWithoutLink = '<p><b>Bold</b>, <i>Italic</i>, Link</p>';
+    var expectedFullHtml = '<p><b>Bold</b>, <i>Italic</i>, <a href="' + testUrl + '">Link</a></p>';
+
+    function selectBoldText() {
+      return helpers.browser.actions()
+                .keyDown(driver.Key.SHIFT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .keyUp(driver.Key.SHIFT)
+                .perform().then( function() {
+                  return helpers.findElementByCss('.st-format-btn--Bold').click();
+                });
+    }
+
+    function selectItalicText() {
+      return helpers.browser.actions()
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .keyDown(driver.Key.SHIFT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .keyUp(driver.Key.SHIFT)
+                .perform().then( function() {
+                  return helpers.findElementByCss('.st-format-btn--Italic').click();
+                });
+    }
+
+    function selectLinkText() {
+      return helpers.browser.actions()
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .keyDown(driver.Key.SHIFT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .sendKeys(driver.Key.ARROW_RIGHT)
+                .keyUp(driver.Key.SHIFT)
+                .perform().then( function() {
+                  return helpers.findElementByCss('.st-format-btn--Link').click();
+                });
+    }
+
+    var parent;
+    helpers.findElementByCss('.st-text-block').then( function(element) {
+      parent = element;
+      return helpers.browser.actions()
+                .mouseMove(parent, {x: 0, y: 30})
+                .click()
+                .perform();
+    }).then(selectBoldText)
+      .then(selectItalicText)
+      .then(selectLinkText)
+      .then(function() {
+        return helpers.completeAlertPopup(testUrl);
+    }).then( function() {
+      return parent.getInnerHtml();
+    }).then( function(html) {
+      expect(html).toBe(expectedFullHtml);
+      return helpers.findElementByCss('.st-format-btn--Unlink').click();
+    }).then( function() {
+      return parent.getInnerHtml();
+    }).then( function(html) {
+      expect(html).toBe(expectedHtmlWithoutLink);
+      done();
+    });
+  });
+
+});

--- a/spec/e2e/helpers.js
+++ b/spec/e2e/helpers.js
@@ -75,6 +75,14 @@ exports.initSirTrevor = function(data) {
   });
 };
 
+exports.completeAlertPopup = function(text) {
+  return exports.browser.wait(driver.until.alertIsPresent()).then( function() {
+    var alert = exports.browser.switchTo().alert();
+    alert.sendKeys(text);
+    return alert.accept();
+  });
+};
+
 beforeAll(function() {
 
   var serverUrl = null;

--- a/src/format-bar.js
+++ b/src/format-bar.js
@@ -64,6 +64,8 @@ Object.assign(FormatBar.prototype, require('./function-bind'), require('./mediat
   },
 
   show: function() {
+    this.hide();
+
     this.editor.$outer.append(this.$el);
     this.$el.addClass('st-format-bar--is-ready');
     this.$el.bind('click', '.st-format-btn', this.onFormatButtonClick);


### PR DESCRIPTION
At times the format bar is already open when a user changes their text selection. This resulted in only odd numbers of text selections actually formatting the selected text.

We now hide the formatbar so it can be reset safely and doesn't need to store state.

General integration tests for the various formatbar options have also been added.