### PR TITLE
Format bar should not hide and re-show on every keypress

### DIFF
--- a/src/format-bar.js
+++ b/src/format-bar.js
@@ -18,6 +18,7 @@ var FormatBar = function(options, mediator, editor) {
   this.options = Object.assign({}, config.defaults.formatBar, options || {});
   this.commands = this.options.commands;
   this.mediator = mediator;
+  this.isShown = false;
 
   this._ensureElement();
   this._bindFunctions();
@@ -59,12 +60,18 @@ Object.assign(FormatBar.prototype, require('./function-bind'), require('./mediat
   },
 
   hide: function() {
+    this.isShown = false;
+
     this.$el.removeClass('st-format-bar--is-ready');
     this.$el.remove();
   },
 
   show: function() {
-    this.hide();
+    if(this.isShown){
+      return;
+    }
+
+    this.isShown = true;
 
     this.editor.$outer.append(this.$el);
     this.$el.addClass('st-format-bar--is-ready');


### PR DESCRIPTION
This fix stops the format bar from being hidden and re-shown on every keystroke. 

This is important if you set a more noticeable animation on the format bar appearing, and then change selection by using [shift+arrow keys].  Previously you see the animation constantly re-running every time the selection updates. With this fix the format bar behaves as expected.

For an example, try defining this animation in `format-bar.scss`:

```
@keyframes format-bar-pop-upwards {
  0% {
    opacity: 0;
    transform: matrix(.97, 0, 0, 1, 0, 12);
  }

  20% {
    opacity: .7;
    transform: matrix(.99, 0, 0, 1, 0, 2);
  }

  40% {
    opacity: 1;
    transform: matrix(1, 0, 0, 1, 0, -1);
  }

  100% {
    transform: matrix(1, 0, 0, 1, 0, 0);
  }
}
```

and then in `.st-format-bar` change:
```
@include transition(opacity 0.2s ease-in-out);
```
for this:
```
animation: format-bar-pop-upwards 160ms forwards linear;
```

Then type some text, and select characters using [shift+arrow].  Compare behaviour before and after fix.