### PR TITLE
Update referenced version of grunt-sass & readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,6 +70,10 @@ Block Types can also easily be added to the ``SirTrevor.Blocks`` object. You can
 
 ### Compiling
 
+Tests are run as part of compilation process, which require `chromedriver` to be installed on
+the machine where you are running the compilation. If you're running Homebrew on OSX this can
+be installed via `brew install chromedriver`.
+
 Before getting started please be sure to install the necessary dependencies via npm:
 
 ``$ npm install``

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-contrib-watch": "^0.3.1",
     "grunt-jasmine-nodejs": "^1.4.2",
     "grunt-karma": "^0.9.0",
-    "grunt-sass": "^0.18.0",
+    "grunt-sass": "~1.1.0",
     "grunt-webpack": "^1.0.8",
     "jasmine-jquery": "^2.0.5",
     "karma": "~0.12.28",


### PR DESCRIPTION
Candidate for resolution of issue: https://github.com/madebymany/sir-trevor-js/issues/400

I've added the note to require chromedriver at the top of the Compilation section, as it applies to both `npm test` as dev, and also `npm run dist`.

Note: My automated tests pass ok with these changes, but I have not done any manual testing.