### PR TITLE
All types are lowercase except for Heading Block

### DIFF
--- a/src/blocks/heading.js
+++ b/src/blocks/heading.js
@@ -9,7 +9,7 @@ var stToHTML = require('../to-html');
 
 module.exports = Block.extend({
 
-  type: 'Heading',
+  type: 'heading',
 
   title: function(){ return i18n.t('blocks:heading:title'); },
 


### PR DESCRIPTION
To be consistent with all other blocks, the type field should be lower case.