### PR TITLE
Separate block positioner select data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.x
 
+* Separate block positioner select data and make it a property of editor instead of block
+
 ### 0.5.0
 
 * Added Scribe for better text formatting rather than custom markdown for better extensibility

--- a/spec/javascripts/units/block_positioner.spec.js
+++ b/spec/javascripts/units/block_positioner.spec.js
@@ -2,12 +2,14 @@
 
 describe("BlockPositioner", function(){
 
-  var positioner, $el, mediator;
+  var positioner, positionerSelect, $el, mediator;
 
   beforeEach(function() {
     $el = $("<div>");
     mediator = Object.assign({}, SirTrevor.Events);
     positioner = new SirTrevor.BlockPositioner($el, mediator);
+    positionerSelect = new SirTrevor.BlockPositionerSelect(mediator);
+    positionerSelect.$positioner = positioner;
   });
 
   describe("onSelectChange", function() {
@@ -16,18 +18,18 @@ describe("BlockPositioner", function(){
     });
 
     it("triggers a block:changePosition when the select value isn't 0", function() {
-      positioner.$select.val = function() { return 2; };
-      positioner.onSelectChange();
+      positionerSelect.$select.val = function() { return 2; };
+      positionerSelect.onSelectChange();
 
-      expect(positioner.mediator.trigger)
+      expect(positionerSelect.mediator.trigger)
         .toHaveBeenCalledWith("block:changePosition", $el, 2, 'after');
     });
 
     it("triggers a block:changePosition with the type set as before when the value is 1", function() {
-      positioner.$select.val = function() { return 1; };
-      positioner.onSelectChange();
+      positionerSelect.$select.val = function() { return 1; };
+      positionerSelect.onSelectChange();
 
-      expect(positioner.mediator.trigger)
+      expect(positionerSelect.mediator.trigger)
         .toHaveBeenCalledWith("block:changePosition", $el, 1, 'before');
     });
   });

--- a/src/block-positioner-select.js
+++ b/src/block-positioner-select.js
@@ -1,0 +1,71 @@
+"use strict";
+
+var template = [
+  "<span class='st-block-positioner__selected-value'></span>",
+  "<select class='st-block-positioner__select'></select>"
+].join("\n");
+
+var BlockPositionerSelect = function(mediator) {
+  this.mediator = mediator;
+
+  this._ensureElement();
+  this._bindFunctions();
+
+  this.initialize();
+};
+
+Object.assign(BlockPositionerSelect.prototype, require('./function-bind'), require('./renderable'), {
+
+  total_blocks: 0,
+
+  bound: ['onBlockCountChange', 'onSelectChange'],
+
+  className: 'st-block-positioner__inner',
+
+  initialize: function(){
+    this.$el.append(template);
+    this.$select = this.$('.st-block-positioner__select');
+    this.$positioner = null;
+
+    this.$select.on('change', this.onSelectChange);
+  },
+
+  onBlockCountChange: function(new_count) {
+    if (new_count !== this.total_blocks) {
+      this.total_blocks = new_count;
+      this.renderPositionList();
+    }
+  },
+
+  onSelectChange: function() {
+    var val = this.$select.val();
+    if (val !== 0) {
+      this.mediator.trigger(
+        "block:changePosition", this.$positioner.$block, val,
+        (val === 1 ? 'before' : 'after'));
+      this.$positioner.toggle();
+    }
+  },
+
+  renderPositionList: function() {
+    var inner = "<option value='0'>" + i18n.t("general:position") + "</option>";
+    for(var i = 1; i <= this.total_blocks; i++) {
+      inner += "<option value="+i+">"+i+"</option>";
+    }
+    this.$select.html(inner);
+  },
+
+  renderInBlock: function(positioner) {
+    // hide old
+    if (this.$positioner && this.$positioner !== positioner) {
+      this.$positioner.hide();
+    }
+    // add new
+    this.$positioner = positioner;
+    this.$select.val(0);
+    positioner.$el.append(this.$el.detach());
+  }
+
+});
+
+module.exports = BlockPositionerSelect;

--- a/src/block-positioner.js
+++ b/src/block-positioner.js
@@ -1,12 +1,5 @@
 "use strict";
 
-var template = [
-  "<div class='st-block-positioner__inner'>",
-  "<span class='st-block-positioner__selected-value'></span>",
-  "<select class='st-block-positioner__select'></select>",
-  "</div>"
-].join("\n");
-
 var BlockPositioner = function(block_element, mediator) {
   this.mediator = mediator;
   this.$block = block_element;
@@ -19,49 +12,16 @@ var BlockPositioner = function(block_element, mediator) {
 
 Object.assign(BlockPositioner.prototype, require('./function-bind'), require('./renderable'), {
 
-  total_blocks: 0,
-
-  bound: ['onBlockCountChange', 'onSelectChange', 'toggle', 'show', 'hide'],
+  bound: ['toggle', 'show', 'hide'],
 
   className: 'st-block-positioner',
   visibleClass: 'st-block-positioner--is-visible',
 
   initialize: function(){
-    this.$el.append(template);
-    this.$select = this.$('.st-block-positioner__select');
-
-    this.$select.on('change', this.onSelectChange);
-
-    this.mediator.on("block:countUpdate", this.onBlockCountChange);
-  },
-
-  onBlockCountChange: function(new_count) {
-    if (new_count !== this.total_blocks) {
-      this.total_blocks = new_count;
-      this.renderPositionList();
-    }
-  },
-
-  onSelectChange: function() {
-    var val = this.$select.val();
-    if (val !== 0) {
-      this.mediator.trigger(
-        "block:changePosition", this.$block, val,
-        (val === 1 ? 'before' : 'after'));
-      this.toggle();
-    }
-  },
-
-  renderPositionList: function() {
-    var inner = "<option value='0'>" + i18n.t("general:position") + "</option>";
-    for(var i = 1; i <= this.total_blocks; i++) {
-      inner += "<option value="+i+">"+i+"</option>";
-    }
-    this.$select.html(inner);
   },
 
   toggle: function() {
-    this.$select.val(0);
+    this.mediator.trigger('block-positioner-select:render', this);
     this.$el.toggleClass(this.visibleClass);
   },
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -18,6 +18,7 @@ var EventBus = require('./event-bus');
 var FormEvents = require('./form-events');
 var BlockControls = require('./block-controls');
 var BlockManager = require('./block-manager');
+var BlockPositionerSelect = require('./block-positioner-select');
 var FloatingBlockControls = require('./floating-block-controls');
 var FormatBar = require('./format-bar');
 var EditorStore = require('./extensions/editor-store');
@@ -31,7 +32,7 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
 
   bound: ['onFormSubmit', 'hideAllTheThings', 'changeBlockPosition',
     'removeBlockDragOver', 'renderBlock', 'resetBlockControls',
-    'blockLimitReached'],
+    'blockLimitReached', 'onBlockCountChange', 'renderBlockPositionerSelect'],
 
   events: {
     'block:reorder:dragend': 'removeBlockDragOver',
@@ -78,12 +79,15 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
     this.block_manager = new BlockManager(this.options, this.ID, this.mediator);
     this.block_controls = new BlockControls(this.block_manager.blockTypes, this.mediator);
     this.fl_block_controls = new FloatingBlockControls(this.$wrapper, this.ID, this.mediator);
+    this.block_positioner_select = new BlockPositionerSelect(this.mediator);
     this.formatBar = new FormatBar(this.options.formatBar, this.mediator, this);
 
     this.mediator.on('block:changePosition', this.changeBlockPosition);
     this.mediator.on('block-controls:reset', this.resetBlockControls);
     this.mediator.on('block:limitReached', this.blockLimitReached);
     this.mediator.on('block:render', this.renderBlock);
+    this.mediator.on("block:countUpdate", this.onBlockCountChange);
+    this.mediator.on("block-positioner-select:render", this.renderBlockPositionerSelect);
 
     this.dataStore = "Please use store.retrieve();";
 
@@ -151,6 +155,14 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
 
   blockLimitReached: function(toggle) {
     this.$wrapper.toggleClass('st--block-limit-reached', toggle);
+  },
+
+  onBlockCountChange: function(new_count) {
+    this.block_positioner_select.onBlockCountChange(new_count);
+  },
+
+  renderBlockPositionerSelect: function(positioner) {
+    this.block_positioner_select.renderInBlock(positioner);
   },
 
   _setEvents: function() {
@@ -288,5 +300,3 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
 });
 
 module.exports = Editor;
-
-

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ var SirTrevor = {
 
   BlockMixins: require('./block_mixins'),
   BlockPositioner: require('./block-positioner'),
+  BlockPositionerSelect: require('./block-positioner-select'),
   BlockReorder: require('./block-reorder'),
   BlockDeletion: require('./block-deletion'),
   BlockValidations: require('./block-validations'),


### PR DESCRIPTION
Hi guys,

This pull request separates the block positioner select data and makes it a property of the editor instead of each block.

Currently each block has a positioner which has its own select list of block numbers. If you add or remove a block, all the lists have to be updated. Furthermore, when loading initial data on page load, this list is updated each time a block is added. This causes unnecessary overhead, and especially with a large number of blocks causes serious performance issues.

This has been discussed in #280. These changes should fix those issues.

There is one notable change in behaviour. Previously when you opened the positioner (by clicking the reorder buttin) in multiple block, the would stay open. Now the select items are detached and moved to the new block, so the positioner will no longer stay open. Personally though I think it's a change for the better.

I'm not sure if the implementation is perfect, but it should work. If you have any thoughts on how to improve it further I might be able to do that.
