### PR TITLE
added radio and checkbox feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ components/
 website/.bundle/
 website/vendor/
 build/*.test.*
+nbproject/

--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,20 @@
 
 Conceived by [Andrew Sprinz](http://github.com/andrewsprinz). Maintained by [Chris Bell](http://github.com/cjbell88) & [Andrew Walker](http://github.com/ninjabiscuit).
 
+## Changes of branch "advanced_blocks"
+
+- Added data serializing for checkboxes and radio buttons (see extended _serializeData in block.js)
+
+  Feature uses data-name attribute of checkboxes/radio-buttons, because name may be the same for a
+  group of widgets (radio buttons), what causes problems during loadData-function:
+  fields have to have different names (provided by appending blockID-prefix).
+  Original field name is accessible through data-name attribute.
+
+  Example snippet in the loadData-function of a custom block (setting an image position value):
+
+        // set radio button value for position
+        this.$('input[name="' + this.blockID + '-position"][value="' + data.position + '"]').prop("checked", true);
+
 ## Upgrade guide from v0.4
 
 - [Changelog](https://github.com/madebymany/sir-trevor-js/blob/master/CHANGELOG.md)

--- a/src/block.js
+++ b/src/block.js
@@ -173,7 +173,31 @@ Object.assign(Block.prototype, SimpleBlock.fn, require('./block-validations'), {
     // Add any inputs to the data attr
     if (this.$(':input').not('.st-paste-block').length > 0) {
       this.$(':input').each(function(index,input){
-        if (input.getAttribute('name')) {
+        if (input.getAttribute('data-name')) {
+          // using data-name attribute, because name may be the same for a group of widgets (radio buttons)
+          // what causes problems during loadData when accessing fields by unique name:
+          // fields have to have different names (blockId prefix added), so data-name was introduced
+          // to overcome this problem and providing original field name
+          if (input.getAttribute('type') === 'number') {
+            data[input.getAttribute('data-name')] = parseInt(input.value);
+          }
+          else if (input.getAttribute('type') === 'checkbox') {
+            var value = "off";
+            if (input.checked === true) {
+              value = "on";
+            }
+            data[input.getAttribute('data-name')] = value;
+          }
+          else if (input.getAttribute('type') === 'radio') {
+            if (input.checked === true) {
+              data[input.getAttribute('data-name')] = input.value;
+            }
+          }
+          else {
+            data[input.getAttribute('data-name')] = input.value;
+          }
+        }
+        else if (input.getAttribute('name')) {
           data[input.getAttribute('name')] = input.value;
         }
       });


### PR DESCRIPTION
Fixes Issue: "Radio buttons are ignored when data is serialized #352"
and also checkboxes.

So advanced Block forms with radio-groups and checkboxes are possible (e.g. an image-upload with additional radios for alignment "left", "right")