### PR TITLE
Allow events to propagate from within blocks

### DIFF
--- a/src/simple-block.js
+++ b/src/simple-block.js
@@ -68,8 +68,6 @@ Object.assign(SimpleBlock.prototype, require('./function-bind'), require('./even
     this.el.insertAdjacentHTML("beforeend", this.block_template(editor_html));
 
     this.inner = this.el.querySelector('.st-block__inner');
-    this.inner.addEventListener('click', function(e){ e.stopPropagation(); });
-    this.inner.addEventListener('mouseover', function(e){ e.stopPropagation(); });
   },
 
   render: function() {


### PR DESCRIPTION
React currently doesn't work within blocks because events are stopped before React can handle them.