### PR TITLE
Moved uploadable events hookup to uploadable.js

### DIFF
--- a/src/block_mixins/uploadable.js
+++ b/src/block_mixins/uploadable.js
@@ -19,6 +19,15 @@ module.exports = {
 
     this.upload_options = Object.assign({}, config.defaults.Block.upload_options, this.upload_options);
     this.inputs.insertAdjacentHTML("beforeend", _.template(this.upload_options.html, this));
+
+    Array.prototype.forEach.call(this.inputs.querySelectorAll('button'), function(button) {
+      button.addEventListener('click', function(ev){ ev.preventDefault(); });
+    });
+    Array.prototype.forEach.call(this.inputs.querySelectorAll('input'), function(input) {
+      input.addEventListener('change', (function(ev) {
+        this.onDrop(ev.currentTarget);
+      }).bind(this));
+    }.bind(this));
   },
 
   uploader: function(file, success, failure){

--- a/src/blocks/image.js
+++ b/src/blocks/image.js
@@ -19,18 +19,6 @@ module.exports = Block.extend({
     this.editor.appendChild(Dom.createElement('img', { src: data.file.url }));
   },
 
-  onBlockRender: function(){
-    /* Setup the upload button */
-    Array.prototype.forEach.call(this.inputs.querySelectorAll('button'), function(button) {
-      button.addEventListener('click', function(ev){ ev.preventDefault(); });
-    });
-    Array.prototype.forEach.call(this.inputs.querySelectorAll('input'), function(input) {
-      input.addEventListener('change', (function(ev) {
-        this.onDrop(ev.currentTarget);
-      }).bind(this));
-    }.bind(this));
-  },
-
   onDrop: function(transferData){
     var file = transferData.files[0],
         urlAPI = (typeof URL !== "undefined") ? URL : (typeof webkitURL !== "undefined") ? webkitURL : null;
@@ -43,7 +31,7 @@ module.exports = Block.extend({
       this.editor.innerHTML = '';
       this.editor.appendChild(Dom.createElement('img', { src: urlAPI.createObjectURL(file) }));
       Dom.show(this.editor);
-      
+
       this.uploader(
         file,
         function(data) {


### PR DESCRIPTION
When they were in the image block, it made the droppable and uploadable
controls hard to use separately. It also clobbered the image block's
`onBlockRender` method, meaning that if you overrided it you had to
seemingly unnecessarily re-implement the events hookup.