### PR TITLE
validateAndSaveBlock should not validate when shouldValidate is false

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -192,7 +192,7 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
   },
 
   validateAndSaveBlock: function(block, shouldValidate) {
-    if ((!config.skipValidation || shouldValidate) && !block.valid()) {
+    if (!config.skipValidation && shouldValidate && !block.valid()) {
       this.mediator.trigger('errors:add', { text: _.result(block, 'validationFailMsg') });
       utils.log("Block " + block.blockID + " failed validation");
       return;


### PR DESCRIPTION
Was calling onBeforeSubmit(false) in order to inject the sir trevor json into our text input w/o validations. 

Noticed that this argument wasn't being picked up correctly by the validateAndSaveBlock. This PR fixes that issue.