### PR TITLE
Add missing blockID argument for block:remove

### DIFF
--- a/src/block-manager.js
+++ b/src/block-manager.js
@@ -126,7 +126,7 @@ Object.assign(BlockManager.prototype, require('./function-bind'), require('./med
     this.triggerBlockCountUpdate();
     this.mediator.trigger('block:limitReached', this.blockLimitReached());
 
-    EventBus.trigger("block:remove");
+    EventBus.trigger('block:remove', blockID);
   },
 
   replaceBlock: function(blockNode, type, data) {


### PR DESCRIPTION
This allows:
```
SirTrevor.EventBus.on('block:remove', function (blockID) {
  console.log(blockID);
});
```