### PR TITLE
Better fallback when you don't want to use Text

### DIFF
--- a/src/block-manager.js
+++ b/src/block-manager.js
@@ -119,8 +119,6 @@ Object.assign(BlockManager.prototype, require('./function-bind'), require('./med
       return (item.blockID !== block.blockID);
     });
 
-    block.remove();
-
     if (options.focusOnPrevious && previousBlock) {
       previousBlock.focusAtEnd();
     }
@@ -134,8 +132,8 @@ Object.assign(BlockManager.prototype, require('./function-bind'), require('./med
 
   replaceBlock: function(blockNode, type, data) {
     var block = this.findBlockById(blockNode.id);
-    this.createBlock(type, data || null, blockNode);
     this.removeBlock(blockNode.id);
+    this.createBlock(type, data || null, blockNode);
     block.remove();
   },
 

--- a/src/block-manager.js
+++ b/src/block-manager.js
@@ -55,7 +55,10 @@ Object.assign(BlockManager.prototype, require('./function-bind'), require('./med
     type = utils.classify(type);
 
     // Run validations
-    if (!this.canCreateBlock(type)) { return; }
+    if (!this.canCreateBlock(type)) {
+      type = utils.classify(this.blockTypes[0]);
+      this.wrapper.classList.add("st-replacer-enable");
+    }
 
     var block = new Blocks[type](data, this.instance_scope, this.mediator,
                                  this.blockOptions);

--- a/src/sass/block-replacer.scss
+++ b/src/sass/block-replacer.scss
@@ -11,7 +11,7 @@
   z-index: 2;
   top: 50%;
   left: 35px;
-  
+
   &::-moz-focus-inner {
     padding:0;
     margin:0;
@@ -22,6 +22,9 @@
     display: block;
   }
 
+  .st-replacer-enable & {
+    display: block;
+  }
 }
 
 .st-block-replacer__button {
@@ -34,7 +37,7 @@
   width: 41px;
   height: 41px;
   cursor: pointer;
-  
+
   transform:translateZ(0);
 
   .st-block--controls-active & {


### PR DESCRIPTION
#473 this modifies block creation so that if Text doesn't exist, we pick the first from specified `blockTypes` as the blockType to create first. If this happens, a class gets added to the wrapper which ensures that the replacer always shows.

As an aside to this issue, I also believe I've fixed an issue where replacement doesn't work if you're at your block limit because block removal happens after creation, so counts don't get updated in time.