### PR TITLE
Fixes an issue affecting multi-line Text blocks

### DIFF
--- a/src/block_mixins/textable.js
+++ b/src/block_mixins/textable.js
@@ -32,7 +32,13 @@ module.exports = {
     if (this._scribe.getTextContent() !== '') {
       var fakeContent = document.createElement('div');
       fakeContent.innerHTML = this.getTextBlockHTML();
-      content = fakeContent.firstChild.innerHTML || fakeContent.innerHTML;
+
+      // We concatenate the content of each paragraph and take into account the new lines
+      content = fakeContent.children &&
+        Array.prototype.slice.call(fakeContent.children).reduce(function (res, child) {
+          return res + child.innerHTML;
+        }, '') || fakeContent.innerHTML;
+
       return content.replace(/^[\s\uFEFF\xA0]+|$/g, '');
     }
     return content;
@@ -64,7 +70,7 @@ module.exports = {
 
     if (options.keepCaretPosition && caretPosition.start !== 0 && caretPosition.end !== 0) {
       selectionRange(this._scribe.el, {
-        start: caretPosition.start, 
+        start: caretPosition.start,
         end: caretPosition.end
       });
     }

--- a/src/blocks/scribe-plugins/scribe-text-block-plugin.js
+++ b/src/blocks/scribe-plugins/scribe-text-block-plugin.js
@@ -24,7 +24,7 @@ var ScribeTextBlockPlugin = function(block) {
       } else {
         div.appendChild(range.cloneContents());
       }
-      
+
       stripFirstEmptyElement(div);
 
       // Sometimes you'll get an empty tag at the start of the block.
@@ -50,6 +50,14 @@ var ScribeTextBlockPlugin = function(block) {
       var range = selection.range.cloneRange();
 
       range.setStartBefore(scribe.el.firstChild, 0);
+
+      var node = range.endContainer.nodeType === 3 ? range.endContainer.parentNode : range.endContainer;
+
+      // We make sure that the caret must be inside the first element to consider
+      // it at the beginning of the block
+      if (scribe.el.firstChild !== node) {
+        return false;
+      }
 
       return rangeToHTML(range, false) === '';
     };


### PR DESCRIPTION
Basically, if the user would create new lines in a `Text` block by pressing Shift + Enter, when hitting the backspace key with the caret at the first position of any line (except the first one), the block would be merged into the previous one instead of merging the lines. Also, just the content of the first line would be kept.

You may want to create some tests so you won't have any regression at some point. I'm happy to help.

[Link to the issue](https://github.com/madebymany/sir-trevor-js/issues/519)