### PR TITLE
`onDragStart` cannot move iframes/embeds

### DIFF
--- a/src/block-reorder.js
+++ b/src/block-reorder.js
@@ -66,7 +66,7 @@ Object.assign(BlockReorder.prototype, require('./function-bind'), require('./ren
     EventBus.trigger("block:reorder:dropped", item_id);
   },
 
-  onDragStart: function onDragStart(ev) {
+  onDragStart: function(ev) {
     var block = this.block;
 
     // Without this blocks are not commited to their new position

--- a/src/block-reorder.js
+++ b/src/block-reorder.js
@@ -66,34 +66,23 @@ Object.assign(BlockReorder.prototype, require('./function-bind'), require('./ren
     EventBus.trigger("block:reorder:dropped", item_id);
   },
 
-  onDragStart: function(ev) {
+  onDragStart: function onDragStart(ev) {
     var block = this.block;
 
-    this.dragEl = block.cloneNode(true);
-    this.dragEl.classList.add("st-drag-element");
-    this.dragEl.style.top = `${block.offsetTop}px`;
-    this.dragEl.style.left = `${block.offsetLeft}px`;
-
-    block.parentNode.appendChild(this.dragEl);
-
-    ev.dataTransfer.setDragImage(this.dragEl, 0, 0);
+    // Without this blocks are not commited to their new position
     ev.dataTransfer.setData("text/plain", this.blockId());
-    this.mediator.trigger("block-controls:hide");
 
+    this.mediator.trigger("block-controls:hide");
     EventBus.trigger("block:reorder:dragstart");
-    block.classList.add('st-block--dragging');
   },
 
   onDragEnd: function(ev) {
     EventBus.trigger("block:reorder:dragend");
-    this.block.classList.remove('st-block--dragging');
-    this.dragEl.parentNode.removeChild(this.dragEl);
   },
 
   render: function() {
     return this;
   }
-
 });
 
 module.exports = BlockReorder;


### PR DESCRIPTION
I am not entirely sure of the underlying issues which cause video/iframe/embed blocks to cause ST `onDragStart` to fail before completing the block drag event, however it affects all iframes, even the Video block that comes with ST by default. The `st-drag-element` class is added to the element, but then all handles are removed and the element is rendered without content.

By removing the following lines of code the user is still able to see where the block is being moved to and the drag event is able to finish successfully with all blocks, text, video, custom iframe. 

This PR is related to https://github.com/madebymany/sir-trevor-js/issues/549