### PR TITLE
Correctly implement config.focusOnInit toggle

### DIFF
--- a/src/block.js
+++ b/src/block.js
@@ -218,6 +218,7 @@ Object.assign(Block.prototype, SimpleBlock.fn, require('./block-validations'), {
   //[> Generic implementation to tell us when the block is active <]
   focus: function() {
     Array.prototype.forEach.call(this.getTextBlock(), function(el) {
+      console.log("fcc");
       el.focus();
     });
   },
@@ -250,10 +251,6 @@ Object.assign(Block.prototype, SimpleBlock.fn, require('./block-validations'), {
   },
 
   _onBlur: function() {},
-
-  onBlockRender: function() {
-    this.focus();
-  },
 
   onDrop: function(dataTransferObj) {},
 

--- a/src/block.js
+++ b/src/block.js
@@ -218,7 +218,6 @@ Object.assign(Block.prototype, SimpleBlock.fn, require('./block-validations'), {
   //[> Generic implementation to tell us when the block is active <]
   focus: function() {
     Array.prototype.forEach.call(this.getTextBlock(), function(el) {
-      console.log("fcc");
       el.focus();
     });
   },

--- a/src/editor.js
+++ b/src/editor.js
@@ -117,14 +117,14 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
       }, this);
     } else if (this.options.defaultType !== false) {
       this.mediator.trigger('block:create', this.options.defaultType, {});
+    }
 
-      if (this.options.focusOnInit) {
-        var blockElement = this.wrapper.querySelectorAll('.st-block')[0];
+    if (this.options.focusOnInit) {
+      var blockElement = this.wrapper.querySelectorAll('.st-block')[0];
 
-        if (blockElement) {
-          var block = this.blockManager.findBlockById(blockElement.getAttribute('id'));
-          block.focus();
-        }
+      if (blockElement) {
+        var block = this.blockManager.findBlockById(blockElement.getAttribute('id'));
+        block.focus();
       }
     }
   },


### PR DESCRIPTION
At present when a block which doesn't override `onBlockRender` is rendered on `initialize` the block will focus.

Remove the default behaviour to fix this.