### PR TITLE
Use config.defaultType option for additions

### DIFF
--- a/src/block-addition-top.js
+++ b/src/block-addition-top.js
@@ -15,7 +15,7 @@ module.exports.create = function(SirTrevor) {
     // REFACTOR: block create event expects data as second argument.
     /*jshint validthis:true */
     SirTrevor.mediator.trigger(
-      "block:create", 'Text', null, this.parentNode.parentNode.previousSibling, { autoFocus: true }
+      "block:create", SirTrevor.options.defaultType, null, this.parentNode.parentNode.previousSibling, { autoFocus: true }
     );
   }
 

--- a/src/block-addition.js
+++ b/src/block-addition.js
@@ -22,7 +22,7 @@ module.exports.create = function(SirTrevor) {
     // REFACTOR: block create event expects data as second argument.
     /*jshint validthis:true */
     SirTrevor.mediator.trigger(
-      "block:create", 'Text', null, this.parentNode.parentNode.id ? this.parentNode.parentNode : this.parentNode
+      "block:create", SirTrevor.options.defaultType, null, this.parentNode.parentNode.id ? this.parentNode.parentNode : this.parentNode
     );
   }
 


### PR DESCRIPTION
The `Text` block type is hard-coded, which makes replacing `Text` with a custom block messy. This PR seeks to use the configured default block type, which can be overridden.