### PR TITLE
Allow users to specify a link target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _SpecRunner.html
 bower_components/
 components/
 .grunt
+yarn-error.log
 npm-debug.log
 website/.bundle/
 website/.tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-**Current version: 0.8.0**
+**Current version: 0.9.0**
 
-## 0.8.x
+## 0.9.x
 
 ### ????
 - [ ] Improve edge content pasting.
@@ -10,11 +10,11 @@
 - [ ] Allow selection of individual list items.
 - [ ] Automated testing for copy / paste.
 
-### 0.8.3 - New block functionality
+### 0.9.0 - New block functionality
 * Add config for multiple heading levels. https://github.com/madebymany/sir-trevor-js/pull/581
 * Allow drop_option label customisation. https://github.com/madebymany/sir-trevor-js/pull/580
 * Use config.defaultType option for additions. https://github.com/madebymany/sir-trevor-js/pull/578
-* [ ] Add external link plugin. https://github.com/madebymany/sir-trevor-js/pull/582
+* Add external link plugin. https://github.com/madebymany/sir-trevor-js/pull/582
 
 ### 0.8.2 - Small fixes
 * Improve list blocks in Chrome where empty item drops down a line.

--- a/locales/de.js
+++ b/locales/de.js
@@ -7,7 +7,6 @@ SirTrevor.Locales.de = {
     'close':            'Schließen',
     'position':         'Position',
     'wait':             'Bitte warten...',
-    'link':             'Link eintragen',
     'yes':              'Ja ',
     'no':               'Nein'
   },
@@ -17,7 +16,21 @@ SirTrevor.Locales.de = {
     'block_empty': "__name__ darf nicht leer sein",
     'type_missing': "Blöcke mit Typ __type__ sind hier nicht zulässig",
     'required_type_empty': "Angeforderter Block-Typ __type__ ist leer",
-    'load_fail': "Es wurde ein Problem beim Laden des Dokumentinhalts festgestellt"
+    'load_fail': "Es wurde ein Problem beim Laden des Dokumentinhalts festgestellt",
+    'link_empty': "This link appears to be empty",
+    'link_invalid': "The link is not valid"
+  },
+  formatters: {
+    link: {
+      'prompt': "Link eintragen",
+      'new_tab': "Opens in a new tab",
+      'message': "The URL you entered appears to be __type__. Do you want to add the required “__prefix__” prefix?",
+      types: {
+        'email': 'an email address',
+        'telephone': 'a telephone number',
+        'url': 'a link'
+      }
+    }
   },
   blocks: {
     text: {

--- a/locales/es.js
+++ b/locales/es.js
@@ -6,8 +6,7 @@ SirTrevor.Locales.es = {
     'upload':           '...o seleccione un fichero',
     'close':            'cerrar',
     'position':         'Posición',
-    'wait':             'Por favor, espere...',
-    'link':             'Introduce un link'
+    'wait':             'Por favor, espere...'
   },
   errors: {
     'title': "Aparecerá el siguiente error :",
@@ -15,7 +14,21 @@ SirTrevor.Locales.es = {
     'block_empty': "__name__ no debe estar vacío",
     'type_missing': "Debe tene un tipo de bloque __type__",
     'required_type_empty': "Un bloque obligatorio de tipo __type__ está vacío",
-    'load_fail': "Hay un problema con la carga de datos"
+    'load_fail': "Hay un problema con la carga de datos",
+    'link_empty': "This link appears to be empty",
+    'link_invalid': "The link is not valid"
+  },
+  formatters: {
+    link: {
+      'prompt': "Introduce un link",
+      'new_tab': "Opens in a new tab",
+      'message': "The URL you entered appears to be __type__. Do you want to add the required “__prefix__” prefix?",
+      types: {
+        'email': 'an email address',
+        'telephone': 'a telephone number',
+        'url': 'a link'
+      }
+    }
   },
   blocks: {
     text: {

--- a/locales/fi.js
+++ b/locales/fi.js
@@ -6,8 +6,7 @@ SirTrevor.Locales.fi = {
     'upload':           '...tai valitse tiedosto',
     'close':            'sulje',
     'position':         'Sijainti',
-    'wait':             'Odota hetki...',
-    'link':             'Kirjoita osoite'
+    'wait':             'Odota hetki...'
   },
   errors: {
     'title': "Seuraavat virheet:",
@@ -15,7 +14,21 @@ SirTrevor.Locales.fi = {
     'block_empty': "__name__ ei saa olla tyhjä",
     'type_missing': "__type__ on pakollinen lohko",
     'required_type_empty': "Pakollinen __type__-lohko on tyhjä",
-    'load_fail': "Sisällön lataamisessa on ongelma"
+    'load_fail': "Sisällön lataamisessa on ongelma",
+    'link_empty': "This link appears to be empty",
+    'link_invalid': "The link is not valid"
+  },
+  formatters: {
+    link: {
+      'prompt': "Kirjoita osoite",
+      'new_tab': "Opens in a new tab",
+      'message': "The URL you entered appears to be __type__. Do you want to add the required “__prefix__” prefix?",
+      types: {
+        'email': 'an email address',
+        'telephone': 'a telephone number',
+        'url': 'a link'
+      }
+    }
   },
   blocks: {
     text: {

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -7,7 +7,6 @@ SirTrevor.Locales.fr = {
     'close':            'fermer',
     'position':         'Position',
     'wait':             'Veuillez patienter...',
-    'link':             'Entrez un lien',
     'yes':              'Oui',
     'no':               'Non'
   },
@@ -17,7 +16,21 @@ SirTrevor.Locales.fr = {
     'block_empty': "__name__ ne doit pas être vide",
     'type_missing': "Vous devez avoir un bloc de type __type__",
     'required_type_empty': "Un bloc requis de type __type__ est vide",
-    'load_fail': "Il y a un problème avec le chargement des données du document"
+    'load_fail': "Il y a un problème avec le chargement des données du document",
+    'link_empty': "This link appears to be empty",
+    'link_invalid': "The link is not valid"
+  },
+  formatters: {
+    link: {
+      'prompt': "Entrez un lien",
+      'new_tab': "Opens in a new tab",
+      'message': "The URL you entered appears to be __type__. Do you want to add the required “__prefix__” prefix?",
+      types: {
+        'email': 'an email address',
+        'telephone': 'a telephone number',
+        'url': 'a link'
+      }
+    }
   },
   blocks: {
     text: {

--- a/locales/pt-BR.js
+++ b/locales/pt-BR.js
@@ -6,8 +6,7 @@ SirTrevor.Locales.pt_BR = {
         'upload':           '...ou escolha um arquivo',
         'close':            'fechar',
         'position':         'Posição',
-        'wait':             'Aguarde...',
-        'link':             'Insira o link'
+        'wait':             'Aguarde...'
       },
       errors: {
         'title': "Você tem os seguintes erros:",
@@ -15,7 +14,21 @@ SirTrevor.Locales.pt_BR = {
         'block_empty': "__name__ não pode ser vazio",
         'type_missing': "Você deve ter um bloco do tipo __type__",
         'required_type_empty': "Um bloco obrigatório do tipo __type__ está vazio",
-        'load_fail': "Houve um problema ao carregar o conteúdo do documento"
+        'load_fail': "Houve um problema ao carregar o conteúdo do documento",
+        'link_empty': "This link appears to be empty",
+        'link_invalid': "The link is not valid"
+      },
+      formatters: {
+        link: {
+          'prompt': "Insira o link",
+          'new_tab': "Opens in a new tab",
+          'message': "The URL you entered appears to be __type__. Do you want to add the required “__prefix__” prefix?",
+          types: {
+            'email': 'an email address',
+            'telephone': 'a telephone number',
+            'url': 'a link'
+          }
+        }
       },
       blocks: {
         text: {

--- a/locales/pt.js
+++ b/locales/pt.js
@@ -6,8 +6,7 @@ SirTrevor.Locales.pt = {
     'upload':           '...ou selecionar um fichero',
     'close':            'Fechar',
     'position':         'Posicionar',
-    'wait':             'Por favor, espere...',
-    'link':             'Introduz um link'
+    'wait':             'Por favor, espere...'
   },
   errors: {
     'title': "Sugerio os seguientes erros :",
@@ -15,7 +14,21 @@ SirTrevor.Locales.pt = {
     'block_empty': "__name__ no debe estar vacío",
     'type_missing': "Necessitas um bloque de __type__",
     'required_type_empty': "Um bloque obligatorio de tipo __type__ está vazio",
-    'load_fail': "Sugerio um problema a cargar os dados do documento"
+    'load_fail': "Sugerio um problema a cargar os dados do documento",
+    'link_empty': "This link appears to be empty",
+    'link_invalid': "The link is not valid"
+  },
+  formatters: {
+    link: {
+      'prompt': "Introduz um link",
+      'new_tab': "Opens in a new tab",
+      'message': "The URL you entered appears to be __type__. Do you want to add the required “__prefix__” prefix?",
+      types: {
+        'email': 'an email address',
+        'telephone': 'a telephone number',
+        'url': 'a link'
+      }
+    }
   },
   blocks: {
     text: {

--- a/locales/ru.js
+++ b/locales/ru.js
@@ -6,8 +6,7 @@ SirTrevor.Locales.ru = {
     'upload':           '... или выберите файл',
     'close':            'Закрыть',
     'position':         'Позиция',
-    'wait':             'Пожалуйста, подождите ...',
-    'link':             'Введите ссылку'
+    'wait':             'Пожалуйста, подождите ...'
   },
   errors: {
     'title': "У вас есть следующие ошибки:",
@@ -15,7 +14,21 @@ SirTrevor.Locales.ru = {
     'block_empty': "__name__ не должно быть пустым",
     'type_missing': "Вы должны иметь блок типа __type__",
     'required_type_empty': "Нужный тип блока __type__ пуст",
-    'load_fail': "Есть проблема при загрузке содержимого документа"
+    'load_fail': "Есть проблема при загрузке содержимого документа",
+    'link_empty': "This link appears to be empty",
+    'link_invalid': "The link is not valid"
+  },
+  formatters: {
+    link: {
+      'prompt': "Введите ссылку",
+      'new_tab': "Opens in a new tab",
+      'message': "The URL you entered appears to be __type__. Do you want to add the required “__prefix__” prefix?",
+      types: {
+        'email': 'an email address',
+        'telephone': 'a telephone number',
+        'url': 'a link'
+      }
+    }
   },
   blocks: {
     text: {

--- a/locales/zh-cn.js
+++ b/locales/zh-cn.js
@@ -6,8 +6,7 @@ SirTrevor.Locales.cn = {
     'upload': '...或者点击上传',
     'close': '关闭',
     'position': '位置',
-    'wait': '处理中，请稍候...',
-    'link': '请填写要插入的链接'
+    'wait': '处理中，请稍候...'
   },
   errors: {
     'title': "发生了以下的错误:",
@@ -15,7 +14,21 @@ SirTrevor.Locales.cn = {
     'block_empty': "__name__ 不能为空",
     'type_missing': "你必须至少有一个 __type__ 类型的模块",
     'required_type_empty': "一个必须不为空的模块 __type__ 目前为空",
-    'load_fail': "载入文档内容失败"
+    'load_fail': "载入文档内容失败",
+    'link_empty': "This link appears to be empty",
+    'link_invalid': "The link is not valid"
+  },
+  formatters: {
+    link: {
+      'prompt': 请填写要插入的链接",
+      'new_tab': "Opens in a new tab",
+      'message': "The URL you entered appears to be __type__. Do you want to add the required “__prefix__” prefix?",
+      types: {
+        'email': 'an email address',
+        'telephone': 'a telephone number',
+        'url': 'a link'
+      }
+    }
   },
   blocks: {
     text: {

--- a/locales/zh-tw.js
+++ b/locales/zh-tw.js
@@ -6,8 +6,7 @@ SirTrevor.Locales.cn_TW = {
     'upload': '...或者點擊上傳',
     'close': '關閉',
     'position': '位置',
-    'wait': '處理中，請稍候...',
-    'link': '請填寫要插入的鏈結'
+    'wait': '處理中，請稍候...'
   },
   errors: {
     'title': "發生了以下的錯誤：",
@@ -15,7 +14,21 @@ SirTrevor.Locales.cn_TW = {
     'block_empty': "__name__ 不能為空",
     'type_missing': "你必須至少有一個 __type__ 類型的模塊",
     'required_type_empty': "一個必須不為空的模塊 __type__ 目前為空",
-    'load_fail': "載入文檔內容失敗"
+    'load_fail': "載入文檔內容失敗",
+    'link_empty': "This link appears to be empty",
+    'link_invalid': "The link is not valid"
+  },
+  formatters: {
+    link: {
+      'prompt': "請填寫要插入的鏈結",
+      'new_tab': "Opens in a new tab",
+      'message': "The URL you entered appears to be __type__. Do you want to add the required “__prefix__” prefix?",
+      types: {
+        'email': 'an email address',
+        'telephone': 'a telephone number',
+        'url': 'a link'
+      }
+    }
   },
   blocks: {
     text: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15771,6 +15771,11 @@
         "regex-cache": "^0.4.2"
       }
     },
+    "micromodal": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.6.tgz",
+      "integrity": "sha512-2VDso2a22jWPpqwuWT/4RomVpoU3Bl9qF9D01xzwlNp5UVsImeA0gY4nSpF44vqcQtQOtkiMUV9EZkAJSRxBsg=="
+    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3458,7 +3458,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -4513,7 +4513,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -6872,7 +6872,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -18912,7 +18912,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -18932,7 +18932,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
@@ -19274,12 +19274,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/scribe-plugin-formatter-plain-text-convert-new-lines-to-html/-/scribe-plugin-formatter-plain-text-convert-new-lines-to-html-0.1.1.tgz",
       "integrity": "sha1-aG4+oKPYGmIqd4ay1YisDXCk600=",
-      "dev": true
-    },
-    "scribe-plugin-link-prompt-command": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/scribe-plugin-link-prompt-command/-/scribe-plugin-link-prompt-command-1.0.0.tgz",
-      "integrity": "sha1-wsSv4OVTUNvOt0ZZL36ct2VKYFg=",
       "dev": true
     },
     "scribe-plugin-sanitizer": {
@@ -20865,7 +20859,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "sass-loader": "^7.1.0",
     "scribe-editor": "git://github.com/madebymany/scribe.git#st-1.0.0",
     "scribe-plugin-formatter-plain-text-convert-new-lines-to-html": "^0.1.1",
-    "scribe-plugin-link-prompt-command": "^1.0.0",
     "scribe-plugin-sanitizer": "git://github.com/madebymany/scribe-plugin-sanitizer.git#st-1.0.0",
     "selection-range": "^1.1.0",
     "selenium-webdriver": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "es5-shim": "^4.5.12",
+    "micromodal": "^0.4.6",
     "svg4everybody": "^2.1.9"
   },
   "devDependencies": {

--- a/src/block-manager.js
+++ b/src/block-manager.js
@@ -372,7 +372,7 @@ Object.assign(BlockManager.prototype, require('./function-bind'), require('./med
         if (blocks.length > 0) { return false; }
 
         this.mediator.trigger('errors:add', {
-          text: i18n.t("errors:required_type_empty", {type: type})
+          text: i18n.t("errors:required_type_empty", { type: type })
         });
 
         utils.log("A required block type " + type + " is empty");

--- a/src/blocks/scribe-plugins/scribe-link-prompt-plugin.js
+++ b/src/blocks/scribe-plugins/scribe-link-prompt-plugin.js
@@ -1,0 +1,161 @@
+"use strict";
+
+const scribeLinkPromptPlugin = function(block) {
+  // ===== INIT ===== //
+  var block = block || {};
+
+  if (!block.transforms) {
+    block.transforms = {};
+  }
+
+  ['pre', 'post'].forEach(function(key) {
+    if (!block.transforms[key]) {
+      block.transforms[key] = [];
+    }
+  });
+
+  // ===== PROMPTS ===== //
+  var userPrompts = [
+    {
+      // For emails we just look for a `@` symbol as it is easier.
+      regexp: /@/,
+      message: 'The URL you entered appears to be an email address. ' +
+      'Do you want to add the required “mailto:” prefix?',
+      action: function(link) {
+        return 'mailto:' + link;
+      }
+    },
+    {
+      // For tel numbers check for + and numerical values
+      regexp: /\+?\d+/,
+      message: 'The URL you entered appears to be a telephone number. ' +
+                'Do you want to add the required “tel:” prefix?',
+      action: function(link) {
+        return 'tel:' + link;
+      }
+    },
+    {
+      regexp: /.+/,
+      message: 'The URL you entered appears to be a link. ' +
+                'Do you want to add the required “http://” prefix?',
+      action: function(link) {
+        return 'http://' + link;
+      }
+    }
+  ];
+
+  function processPrompt(window, link) {
+    for (var i = 0; i < userPrompts.length; i++) {
+      var prompt = userPrompts[i];
+
+      if (prompt.regexp.test(link)) {
+        var userResponse = window.confirm(prompt.message);
+
+        if (userResponse) {
+          // Only process the first prompt
+          return prompt.action(link);
+        }
+      }
+
+    };
+
+    return link;
+  }
+
+  // ===== CHECKS ===== //
+  var urlProtocolRegExp = /^https?\:\/\//;
+  var mailtoProtocolRegExp = /^mailto\:/;
+  var telProtocolRegExp = /^tel\:/;
+  var knownProtocols = [urlProtocolRegExp, mailtoProtocolRegExp, telProtocolRegExp];
+
+  function emptyLink(string) {
+    return /\w/.test(string);
+  }
+
+  function hasKnownProtocol(urlValue) {
+    // If a http/s or mailto link is provided, then we will trust that an link is valid
+    return knownProtocols.some(function(protocol) { return protocol.test(urlValue)});
+  }
+
+  // ===== TRANSFORMS ===== //
+  function runTransforms(transforms, initialLink) {
+    return transforms.reduce(function(currentLinkValue, transform) {
+      return transform(currentLinkValue);
+      }, initialLink);
+  }
+
+  return function(scribe) {
+    const linkPromptCommand = new scribe.api.Command('link');
+    linkPromptCommand.nodeName = 'A';
+
+    headingCommand.queryEnabled = () => {
+      return block.inline_editable;
+    };
+
+    headingCommand.queryState = () => {
+      /**
+       * We override the native `document.queryCommandState` for links because
+       * the `createLink` and `unlink` commands are not supported.
+       * As per: http://jsbin.com/OCiJUZO/1/edit?js,console,output
+       */
+      var selection = new scribe.api.Selection();
+      return !! selection.getContaining(function (node) {
+        return node.nodeName === this.nodeName;
+      }.bind(this));
+    };
+
+    headingCommand.execute = function headingCommandExecute(passedLink) {
+      var link;
+      var selection = new scribe.api.Selection();
+      var range = selection.range;
+      var anchorNode = selection.getContaining(function(node) {
+        return node.nodeName === this.nodeName;
+      }.bind(this));
+
+      var initialLink = anchorNode ? anchorNode.href : '';
+
+      if (!passedLink)  {
+        link = window.prompt('Enter a link.', initialLink);
+      } else {
+        link = passedLink;
+      }
+
+      link = runTransforms(block.transforms.pre, link);
+
+      if (!emptyLink(link)) {
+        window.alert('This link appears empty');
+        return;
+      }
+
+      if (options && options.validation) {
+        var validationResult = block.validation(link);
+
+        if (!validationResult.valid) {
+          window.alert(validationResult.message || 'The link is not valid');
+          return;
+        }
+      }
+
+      if (anchorNode) {
+        range.selectNode(anchorNode);
+        selection.selection.removeAllRanges();
+        selection.selection.addRange(range);
+      }
+
+      link = window.prompt('Enter a link target (Enter "_blank" to make the link open in a new tab, leave black to open in the same page).');
+
+      if (link) {
+        if (!hasKnownProtocol(link) ) {
+          link = processPrompt(window, link);
+        }
+
+        link = runTransforms(options.transforms.post, link);
+        scribe.api.SimpleCommand.prototype.execute.call(this, link);
+      }
+    };
+
+    scribe.commands.link = linkCommand;
+  };
+};
+
+module.exports = scribeLinkPromptPlugin;

--- a/src/blocks/scribe-plugins/scribe-link-prompt-plugin.js
+++ b/src/blocks/scribe-plugins/scribe-link-prompt-plugin.js
@@ -85,7 +85,7 @@ const scribeLinkPromptPlugin = function(block) {
   }
 
   return function(scribe) {
-    const linkPromptCommand = new scribe.api.Command('link');
+    const linkPromptCommand = new scribe.api.Command('linkPrompt');
     linkPromptCommand.nodeName = 'A';
 
     headingCommand.queryEnabled = () => {

--- a/src/blocks/scribe-plugins/scribe-link-prompt-plugin.js
+++ b/src/blocks/scribe-plugins/scribe-link-prompt-plugin.js
@@ -20,7 +20,7 @@ const scribeLinkPromptPlugin = function(block) {
       // For emails we just look for a `@` symbol as it is easier.
       regexp: /@/,
       message: 'The URL you entered appears to be an email address. ' +
-      'Do you want to add the required “mailto:” prefix?',
+               'Do you want to add the required “mailto:” prefix?',
       action: function(link) {
         return 'mailto:' + link;
       }
@@ -29,7 +29,7 @@ const scribeLinkPromptPlugin = function(block) {
       // For tel numbers check for + and numerical values
       regexp: /\+?\d+/,
       message: 'The URL you entered appears to be a telephone number. ' +
-                'Do you want to add the required “tel:” prefix?',
+               'Do you want to add the required “tel:” prefix?',
       action: function(link) {
         return 'tel:' + link;
       }
@@ -81,7 +81,7 @@ const scribeLinkPromptPlugin = function(block) {
   function runTransforms(transforms, initialLink) {
     return transforms.reduce(function(currentLinkValue, transform) {
       return transform(currentLinkValue);
-      }, initialLink);
+    }, initialLink);
   }
 
   return function(scribe) {
@@ -99,9 +99,9 @@ const scribeLinkPromptPlugin = function(block) {
        * As per: http://jsbin.com/OCiJUZO/1/edit?js,console,output
        */
       var selection = new scribe.api.Selection();
-      return !! selection.getContaining(function (node) {
-        return node.nodeName === this.nodeName;
-      }.bind(this));
+      return !! selection.getContaining(function(node) {
+        return node.nodeName === linkPromptCommand.nodeName;
+      });
     };
 
     linkPromptCommand.execute = function linkPromptCommandExecute(passedLink) {
@@ -109,8 +109,8 @@ const scribeLinkPromptPlugin = function(block) {
       var selection = new scribe.api.Selection();
       var range = selection.range;
       var anchorNode = selection.getContaining(function(node) {
-        return node.nodeName === this.nodeName;
-      }.bind(this));
+        return node.nodeName === linkPromptCommand.nodeName;
+      });
 
       var initialLink = anchorNode ? anchorNode.href : '';
 
@@ -127,7 +127,7 @@ const scribeLinkPromptPlugin = function(block) {
         return;
       }
 
-      if (options && options.validation) {
+      if (block && block.validation) {
         var validationResult = block.validation(link);
 
         if (!validationResult.valid) {
@@ -142,19 +142,20 @@ const scribeLinkPromptPlugin = function(block) {
         selection.selection.addRange(range);
       }
 
-      link = window.prompt('Enter a link target (Enter "_blank" to make the link open in a new tab, leave black to open in the same page).');
-
       if (link) {
         if (!hasKnownProtocol(link) ) {
           link = processPrompt(window, link);
         }
 
-        link = runTransforms(options.transforms.post, link);
-        scribe.api.SimpleCommand.prototype.execute.call(this, link);
+        link = runTransforms(block.transforms.post, link);
+
+        var target = window.prompt('Enter a link target (Enter "_blank" to make the link open in a new tab, leave black to open in the same page).');  
+        var html = `<a href="${link}" target="${target}">${selection.selection}</a>`;
+        document.execCommand('insertHTML', false, html);
       }
     };
 
-    scribe.commands.link = linkPromptCommand;
+    scribe.commands.linkPrompt = linkPromptCommand;
   };
 };
 

--- a/src/blocks/scribe-plugins/scribe-link-prompt-plugin.js
+++ b/src/blocks/scribe-plugins/scribe-link-prompt-plugin.js
@@ -88,11 +88,11 @@ const scribeLinkPromptPlugin = function(block) {
     const linkPromptCommand = new scribe.api.Command('linkPrompt');
     linkPromptCommand.nodeName = 'A';
 
-    headingCommand.queryEnabled = () => {
+    linkPromptCommand.queryEnabled = () => {
       return block.inline_editable;
     };
 
-    headingCommand.queryState = () => {
+    linkPromptCommand.queryState = () => {
       /**
        * We override the native `document.queryCommandState` for links because
        * the `createLink` and `unlink` commands are not supported.
@@ -104,7 +104,7 @@ const scribeLinkPromptPlugin = function(block) {
       }.bind(this));
     };
 
-    headingCommand.execute = function headingCommandExecute(passedLink) {
+    linkPromptCommand.execute = function linkPromptCommandExecute(passedLink) {
       var link;
       var selection = new scribe.api.Selection();
       var range = selection.range;
@@ -154,7 +154,7 @@ const scribeLinkPromptPlugin = function(block) {
       }
     };
 
-    scribe.commands.link = linkCommand;
+    scribe.commands.link = linkPromptCommand;
   };
 };
 

--- a/src/blocks/text.js
+++ b/src/blocks/text.js
@@ -10,6 +10,7 @@ var stToHTML = require('../to-html');
 var ScribeTextBlockPlugin = require('./scribe-plugins/scribe-text-block-plugin');
 var ScribePastePlugin = require('./scribe-plugins/scribe-paste-plugin');
 var ScribeHeadingPlugin = require('./scribe-plugins/scribe-heading-plugin');
+var ScribeLinkPromptPlugin = require('./scribe-plugins/scribe-link-prompt-plugin');
 var ScribeQuotePlugin = require('./scribe-plugins/scribe-quote-plugin');
 
 module.exports = Block.extend({
@@ -28,6 +29,7 @@ module.exports = Block.extend({
     scribe.use(new ScribeTextBlockPlugin(this));
     scribe.use(new ScribePastePlugin(this));
     scribe.use(new ScribeHeadingPlugin(this));
+    scribe.use(new ScribeLinkPromptPlugin(this));
     scribe.use(new ScribeQuotePlugin(this));
 
     scribe.on('content-changed', this.toggleEmptyClass.bind(this));

--- a/src/editor.js
+++ b/src/editor.js
@@ -374,7 +374,7 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
                   'class': 'st-outer notranslate',
                   'dropzone': 'copy link move'});
 
-    var wrapper = Dom.createElement("div", {'class': 'st-blocks'});
+    var wrapper = Dom.createElement("div", { 'class': 'st-blocks' });
 
     // Wrap our element in lots of containers *eww*
 

--- a/src/locales.js
+++ b/src/locales.js
@@ -14,9 +14,9 @@ var Locales = {
       'close':            'close',
       'position':         'Position',
       'wait':             'Please wait...',
-      'link':             'Enter a link',
       'yes':              'Yes',
-      'no':               'No'
+      'no':               'No',
+      'submit':           'Submit'
     },
     errors: {
       'title': "You have the following errors:",
@@ -24,7 +24,21 @@ var Locales = {
       'block_empty': "__name__ must not be empty",
       'type_missing': "You must have a block of type __type__",
       'required_type_empty': "A required block type __type__ is empty",
-      'load_fail': "There was a problem loading the contents of the document"
+      'load_fail': "There was a problem loading the contents of the document",
+      'link_empty': "This link appears to be empty",
+      'link_invalid': "The link is not valid"
+    },
+    formatters: {
+      link: {
+        'prompt': "Enter a link",
+        'new_tab': "Opens in a new tab",
+        'message': "The URL you entered appears to be __type__. Do you want to add the required “__prefix__” prefix?",
+        types: {
+          'email': 'an email address',
+          'telephone': 'a telephone number',
+          'url': 'a link'
+        }
+      }
     },
     blocks: {
       text: {

--- a/src/packages/dom.js
+++ b/src/packages/dom.js
@@ -99,9 +99,15 @@ Dom.createDocumentFragmentFromString = function(html) {
   elem.innerHTML = html;
 
   while (elem.childNodes[0]) {
-      frag.appendChild(elem.childNodes[0]);
+    frag.appendChild(elem.childNodes[0]);
   }
   return frag;
+};
+
+Dom.createElementFromString = function(html) {
+  var elem = document.createElement('div');
+  elem.innerHTML = html;
+  return elem.childNodes[0];
 };
 
 module.exports = Dom;

--- a/src/packages/modal.js
+++ b/src/packages/modal.js
@@ -1,0 +1,81 @@
+"use strict";
+
+/**
+ * Modal
+ * --
+ * Displayed for extra options.
+ */
+
+var MicroModal = require('micromodal').default;
+var Dom = require("./dom");
+var _ = require('../lodash');
+
+var template = [
+  '<div class="modal micromodal-slide" id="<%= id %>" aria-hidden="true">',
+    '<div class="modal__overlay" tabindex="-1" data-micromodal-close>',
+      '<form class="modal__container" role="dialog" aria-modal="true" aria-labelledby="<%= id %>-title" novalidate>',
+        '<header class="modal__header">',
+          '<h2 class="modal__title" id="<%= id %>-title"><%= args.title %></h2>',
+          '<button class="modal__close" aria-label="Close modal" data-micromodal-close></button>',
+        '</header>',
+        '<main class="modal__content" id="<%= id %>-content"><%= args.description %></main>',
+        '<footer class="modal__footer">',
+          '<button id="<%= id %>-submit" class="modal__btn">',
+            i18n.t("general:submit"),
+          '</button>',
+        '</footer>',
+      '</form>',
+    '</div>',
+  '</div>'
+].join("\n");
+
+var Modal = function() {
+  this.initialize();
+};
+
+Object.assign(Modal.prototype, {
+
+  id: 'sirtrevor-modal',
+
+  initialize: function() {
+    this.el = document.getElementById(this.id);
+    MicroModal.init();
+  },
+
+  submit: function() {
+    if (this.callback(this)) {
+      this.hide();
+    }
+  },
+
+  show: function(args, callback) {
+    this.callback = callback;
+    var element = _.template(template, { id: this.id, args: args });
+    element = Dom.createElementFromString(element);
+    element.querySelector('form').addEventListener('submit', event => {
+      this.submit();
+      event.preventDefault();
+    })
+
+    if (this.el) {
+      document.body.replaceChild(element, this.el)
+    } else {
+      document.body.appendChild(element);
+    }
+
+    this.el = element;
+    MicroModal.show(this.id);
+  },
+
+  hide: function() {
+    MicroModal.close(this.id);
+  },
+
+  remove: function() {
+    MicroModal.close(this.id);
+    Dom.remove(this.el);
+  },
+
+});
+
+module.exports = Modal;

--- a/src/sass/block.scss
+++ b/src/sass/block.scss
@@ -128,7 +128,7 @@
   @include st-input-active;
   font-size: $text-block-font-size;
   line-height: 1.45;
-  overflow:visible;
+  overflow: visible;
 
   .st-block--empty & {
     line-height: 55px;
@@ -240,20 +240,11 @@ ul.st-text-block {
 }
 
 .st-upload-btn {
-  border: 0;
-  background: $base-ui-color;
-  border-radius: 0.2em;
-  padding: 0.35em 1em;
-  font-size: 1.125em;
-  cursor: pointer;
-  color: #fff;
-  position: relative;
-  z-index: 10;
+  @include st-btn;
 }
 
 .st-block__upload-container:hover .st-upload-btn {
-  background:$accent-color;
-  color: #fff;
+  @include st-btn-hover;
 }
 
 .st-block__editor--with-square-media {

--- a/src/sass/inputs.scss
+++ b/src/sass/inputs.scss
@@ -10,7 +10,6 @@
 @mixin st-input {
   font-size: inherit;
   margin: 0;
-  /*padding: 0.3em 0;*/
 }
 
 .st-block input[type="text"],
@@ -22,6 +21,12 @@
 @mixin st-input-active {
   outline: none;
   border: none;
+}
+
+@mixin st-input-styled {
+  color: $base-ui-color;
+  border: 0.1em solid #d4d4d4;
+  padding: 0.6em;
 }
 
 .st-block [contenteditable="true"],
@@ -39,7 +44,32 @@
 .st-block input[type="text"],
 .st-block input[type="text"]:active,
 .st-block input[type="text"]:focus {
-  color: #42474b;
-  border: 0.1em solid #d4d4d4;
-  padding:.6em;
+  @include st-input-styled;
+}
+
+// Generic styles
+@mixin st-btn-hover {
+  background: $accent-color;
+  color: #fff;
+}
+
+@mixin st-btn {
+  border: 0;
+  background: $base-ui-color;
+  border-radius: 0.2em;
+  padding: 0.35em 1em;
+  font-size: 1.125em;
+  cursor: pointer;
+  color: #fff;
+  position: relative;
+  z-index: 10;
+
+  &:hover {
+    @include st-btn-hover;
+  }
+}
+
+.st-block__upload-container:hover .st-upload-btn {
+  background: $accent-color;
+  color: #fff;
 }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -22,3 +22,6 @@
 
 // Format Bar
 @import 'format-bar';
+
+// Modal
+@import 'modal';

--- a/src/sass/modal.scss
+++ b/src/sass/modal.scss
@@ -1,0 +1,129 @@
+
+.modal__overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 2;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal__container {
+  background-color: #fff;
+  padding: 30px;
+  min-width: 360px;
+  max-width: 500px;
+  max-height: 100vh;
+  border-radius: 4px;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modal__title {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.25;
+  color: $accent-color;
+  box-sizing: border-box;
+}
+
+.modal__close {
+  background: transparent;
+  border: 0;
+}
+
+.modal__header .modal__close:before {
+  content: "\2715";
+}
+
+.modal__content {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  line-height: 1.5;
+  color: rgba(0,0,0,.8);
+}
+
+.modal__btn {
+  @include st-btn;
+  font-size: 1em;
+}
+
+
+// ===== Inputs ====== //
+.modal__container label {
+  display: inline-block;
+  font-weight: bold;
+  margin-bottom: 0.25em;
+}
+
+.modal__container input:not([type="checkbox"]) {
+  @include st-input;
+  @include st-input-active;
+  @include st-input-styled;
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+
+// ===== Demo Animation Style ===== //
+@keyframes mmfadeIn {
+    from { opacity: 0; }
+      to { opacity: 1; }
+}
+
+@keyframes mmfadeOut {
+    from { opacity: 1; }
+      to { opacity: 0; }
+}
+
+@keyframes mmslideIn {
+  from { transform: translateY(15%); }
+    to { transform: translateY(0); }
+}
+
+@keyframes mmslideOut {
+    from { transform: translateY(0); }
+    to { transform: translateY(-10%); }
+}
+
+.micromodal-slide {
+  display: none;
+}
+
+.micromodal-slide.is-open {
+  display: block;
+}
+
+.micromodal-slide[aria-hidden="false"] .modal__overlay {
+  animation: mmfadeIn .3s cubic-bezier(0.0, 0.0, 0.2, 1);
+}
+
+.micromodal-slide[aria-hidden="false"] .modal__container {
+  animation: mmslideIn .3s cubic-bezier(0, 0, .2, 1);
+}
+
+.micromodal-slide[aria-hidden="true"] .modal__overlay {
+  animation: mmfadeOut .3s cubic-bezier(0.0, 0.0, 0.2, 1);
+}
+
+.micromodal-slide[aria-hidden="true"] .modal__container {
+  animation: mmslideOut .3s cubic-bezier(0, 0, .2, 1);
+}
+
+.micromodal-slide .modal__container,
+.micromodal-slide .modal__overlay {
+  will-change: transform;
+}

--- a/src/scribe-interface.js
+++ b/src/scribe-interface.js
@@ -5,7 +5,7 @@ var Scribe = require('scribe-editor');
 var config = require('./config');
 
 var scribePluginFormatterPlainTextConvertNewLinesToHTML = require('scribe-plugin-formatter-plain-text-convert-new-lines-to-html');
-var scribePluginLinkPromptCommand = require('scribe-plugin-link-prompt-command');
+var scribePluginLinkPromptCommand = require('./blocks/scribe-plugins/scribe-link-prompt-plugin');
 var scribePluginSanitizer = require('scribe-plugin-sanitizer');
 
 var sanitizeDefaults = {


### PR DESCRIPTION
When you make some text into a link you are given a prompt to set the URL. This adds a second prompt where you can set the `target` attribute of the link.