### PR TITLE
remove disableBackButton function that's breaking other input fields

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -105,7 +105,6 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
 
     // External event listeners
     window.addEventListener('click', this.hideAllTheThings);
-    document.body.addEventListener('keydown', this.disableBackButton);
 
     this.createBlocks();
     this.wrapper.classList.add('st-ready');
@@ -158,7 +157,6 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
 
     // Remove external event listeners
     window.removeEventListener('click', this.hideAllTheThings);
-    document.body.removeEventListener('keydown', this.disableBackButton);
 
     // Clear the store
     this.store.reset();
@@ -314,23 +312,6 @@ Object.assign(Editor.prototype, require('./function-bind'), require('./events'),
     utils.log("Adding data for block " + block.blockID + " to block store:",
               blockData);
     this.store.addData(blockData);
-  },
-
-  /*
-   * Disable back button so when a block loses focus the user
-   * pressing backspace multiple times doesn't close the page.
-   */
-  disableBackButton: function(e) {
-    var target = e.target || e.srcElement;
-    if (e.keyCode === 8) {
-      if (target.getAttribute('contenteditable') ||
-          target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA') {
-        return;
-      }
-
-      e.preventDefault();
-    }
   },
 
   findBlockById: function(block_id) {


### PR DESCRIPTION
disableBackButton function was used to stop browsers leaving the page and losing eg form input data. 
This has now been phased out of browsers- see https://www.mozilla.org/en-US/firefox/87.0/releasenotes/?_gl=1*885zv9*_ga*Mzg2NzQ0Nzc5LjE2OTQ2MDE5ODY.*_ga_2VC139B3XV*MTcwOTc0MDM5Mi4xLjEuMTcwOTc0MDQ1My4wLjAuMA.. and https://9to5google.com/2016/05/20/chrome-52-backspace-shortcut-gone/ 

It is now stopping the backspace from working as expected on input fields on my form so this PR is to remove it completely as it is no longer necessary.